### PR TITLE
Add error handling for storage.store_sample()

### DIFF
--- a/lib/bipbip/storage/copperegg.rb
+++ b/lib/bipbip/storage/copperegg.rb
@@ -42,7 +42,7 @@ module Bipbip
     def store_sample(plugin, time, data)
       response = CopperEgg::MetricSample.save(plugin.metric_group, plugin.source_identifier, time.to_i, data)
       if response.code != '200'
-        raise("Cannot store copperegg data `#{data}`. Response code `#{response.code}`, message `#{response.message}`")
+        raise("Cannot store copperegg data `#{data}`. Response code `#{response.code}`, message `#{response.message}`, body `#{response.body}`")
       end
     end
 

--- a/lib/bipbip/storage/copperegg.rb
+++ b/lib/bipbip/storage/copperegg.rb
@@ -40,7 +40,10 @@ module Bipbip
     end
 
     def store_sample(plugin, time, data)
-      CopperEgg::MetricSample.save(plugin.metric_group, plugin.source_identifier, time.to_i, data)
+      response = CopperEgg::MetricSample.save(plugin.metric_group, plugin.source_identifier, time.to_i, data)
+      if response.code != '200'
+        raise("Cannot store copperegg data `#{data}`. Response code `#{response.code}`, message `#{response.message}`")
+      end
     end
 
     def _load_metric_groups

--- a/lib/bipbip/version.rb
+++ b/lib/bipbip/version.rb
@@ -1,3 +1,3 @@
 module Bipbip
-  VERSION = '0.5.8'
+  VERSION = '0.5.9'
 end


### PR DESCRIPTION
Currently if store_sample() fails the bipbip doesn't know that metric is not saved in storage.