### PR TITLE
Mongodb: Slow queries should be per second?

### DIFF
--- a/lib/bipbip/plugin/mongodb.rb
+++ b/lib/bipbip/plugin/mongodb.rb
@@ -108,8 +108,7 @@ module Bipbip
 
       slow_queries = find_slow_queries_count({'millis' => {'$gte' => slow_query_threshold}, 'ts' => {'$gte' => timestamp_last_check}})
 
-      measure_period = (Time.now - timestamp_last_check)
-      (slow_queries/(measure_period <= 1 ? 1 : measure_period)).to_i
+      (slow_queries/(Time.now - timestamp_last_check)).to_i
     end
 
     def find_slow_queries_count(query)

--- a/lib/bipbip/plugin/mongodb.rb
+++ b/lib/bipbip/plugin/mongodb.rb
@@ -62,7 +62,7 @@ module Bipbip
         data['replication_lag'] = replication_lag
       end
 
-      data['slow_queries'] = fetch_slow_queries
+      data['slow_queries'] = calculate_slow_queries
 
       data
     end
@@ -103,15 +103,15 @@ module Bipbip
       old
     end
 
-    def fetch_slow_queries
+    def calculate_slow_queries
       timestamp_last_check = slow_query_last_check
 
-      slow_queries = find_slow_queries_count(slow_query_threshold, timestamp_last_check)
+      slow_queries = fetch_slow_queries_count(slow_query_threshold, timestamp_last_check)
 
       (slow_queries/(Time.now - timestamp_last_check)).to_i
     end
 
-    def find_slow_queries_count(millis_min, ts_min)
+    def fetch_slow_queries_count(millis_min, ts_min)
       query = {'millis' => {'$gte' => millis_min}, 'ts' => {'$gte' => ts_min}}
       database_names_ignore = ['admin', 'system']
 

--- a/lib/bipbip/plugin/mongodb.rb
+++ b/lib/bipbip/plugin/mongodb.rb
@@ -62,7 +62,7 @@ module Bipbip
         data['replication_lag'] = replication_lag
       end
 
-      data['slow_queries'] = fetch_slow_queries
+      data['slow_queries'] = (fetch_slow_queries/config['frequency'])
 
       data
     end

--- a/lib/bipbip/plugin/mongodb.rb
+++ b/lib/bipbip/plugin/mongodb.rb
@@ -106,13 +106,15 @@ module Bipbip
     def fetch_slow_queries
       timestamp_last_check = slow_query_last_check
 
-      slow_queries = find_slow_queries_count({'millis' => {'$gte' => slow_query_threshold}, 'ts' => {'$gte' => timestamp_last_check}})
+      slow_queries = find_slow_queries_count(slow_query_threshold, timestamp_last_check)
 
       (slow_queries/(Time.now - timestamp_last_check)).to_i
     end
 
-    def find_slow_queries_count(query)
+    def find_slow_queries_count(millis_min, ts_min)
+      query = {'millis' => {'$gte' => millis_min}, 'ts' => {'$gte' => ts_min}}
       database_names_ignore = ['admin', 'system']
+
       database_list = (mongodb_client.database_names - database_names_ignore).map { |name| mongodb_database(name) }
       database_list.reduce(0) { |memo, database| memo + database.collection('system.profile').count({:query => query}) }
     end

--- a/lib/bipbip/version.rb
+++ b/lib/bipbip/version.rb
@@ -1,3 +1,3 @@
 module Bipbip
-  VERSION = '0.5.13'
+  VERSION = '0.5.14'
 end

--- a/spec/bipbip/plugin/mongodb_spec.rb
+++ b/spec/bipbip/plugin/mongodb_spec.rb
@@ -50,6 +50,9 @@ describe Bipbip::Plugin::Mongodb do
     plugin.stub(:find_slow_queries_count).and_return(100)
     plugin.stub(:slow_query_last_check).and_return(Time.now - 5, Time.now)
 
+    plugin.stub(:fetch_server_status).and_return({})
+    plugin.stub(:fetch_replica_status).and_return({})
+
     data = plugin.monitor
     data['slow_queries'].should be < 20
 

--- a/spec/bipbip/plugin/mongodb_spec.rb
+++ b/spec/bipbip/plugin/mongodb_spec.rb
@@ -48,9 +48,12 @@ describe Bipbip::Plugin::Mongodb do
 
   it 'should collect slow queries per second' do
     plugin.stub(:find_slow_queries_count).and_return(100)
-    plugin.stub(:slow_query_last_check).and_return(Time.now - 5)
+    plugin.stub(:slow_query_last_check).and_return(Time.now - 5, Time.now)
 
     data = plugin.monitor
     data['slow_queries'].should be < 20
+
+    data = plugin.monitor
+    data['slow_queries'].should be > 100
   end
 end

--- a/spec/bipbip/plugin/mongodb_spec.rb
+++ b/spec/bipbip/plugin/mongodb_spec.rb
@@ -15,7 +15,7 @@ describe Bipbip::Plugin::Mongodb do
             }
         })
 
-    plugin.stub(:fetch_slow_queries).and_return(12)
+    plugin.stub(:calculate_slow_queries).and_return(12)
 
     data = plugin.monitor
     data['connections_current'].should eq(100)
@@ -40,14 +40,14 @@ describe Bipbip::Plugin::Mongodb do
             ]
         })
 
-    plugin.stub(:find_slow_queries_count).and_return(0)
+    plugin.stub(:calculate_slow_queries).and_return(0)
 
     data = plugin.monitor
     data['replication_lag'].should eq(3)
   end
 
   it 'should collect slow queries per second' do
-    plugin.stub(:find_slow_queries_count).and_return(100)
+    plugin.stub(:fetch_slow_queries_count).and_return(100)
     plugin.stub(:slow_query_last_check).and_return(Time.now - 5, Time.now)
 
     plugin.stub(:fetch_server_status).and_return({})

--- a/spec/bipbip/plugin/mongodb_spec.rb
+++ b/spec/bipbip/plugin/mongodb_spec.rb
@@ -15,12 +15,12 @@ describe Bipbip::Plugin::Mongodb do
             }
         })
 
-    plugin.stub(:find_slow_queries_count).and_return(88)
+    plugin.stub(:fetch_slow_queries).and_return(12)
 
     data = plugin.monitor
     data['connections_current'].should eq(100)
     data['mem_resident'].should eq(1024)
-    data['slow_queries'].should eq(88)
+    data['slow_queries'].should eq(12)
   end
 
   it 'should collect replication lag' do
@@ -51,6 +51,6 @@ describe Bipbip::Plugin::Mongodb do
     plugin.stub(:slow_query_last_check).and_return(Time.now - 5)
 
     data = plugin.monitor
-    data['slow_queries'].should be < 50
+    data['slow_queries'].should be < 20
   end
 end

--- a/spec/bipbip/plugin/mongodb_spec.rb
+++ b/spec/bipbip/plugin/mongodb_spec.rb
@@ -2,7 +2,7 @@ require 'bipbip'
 require 'bipbip/plugin/mongodb'
 
 describe Bipbip::Plugin::Mongodb do
-  let(:plugin) { Bipbip::Plugin::Mongodb.new('mongodb', {'hostname' => 'localhost', 'port' => 27017}, 10) }
+  let(:plugin) { Bipbip::Plugin::Mongodb.new('mongodb', {'hostname' => 'localhost', 'port' => 27017, 'frequency' => 4}, 10) }
 
   it 'should collect data' do
     plugin.stub(:fetch_server_status).and_return(
@@ -15,12 +15,12 @@ describe Bipbip::Plugin::Mongodb do
             }
         })
 
-    plugin.stub(:fetch_slow_queries).and_return(12)
+    plugin.stub(:fetch_slow_queries).and_return(88)
 
     data = plugin.monitor
     data['connections_current'].should eq(100)
     data['mem_resident'].should eq(1024)
-    data['slow_queries'].should eq(12)
+    data['slow_queries'].should eq(22)
   end
 
   it 'should collect replication lag' do


### PR DESCRIPTION
Currently we measure the number of slow queries per *measurement interval* (5 secs in our case).
I think we should normalize it to 1 second, so it's independent of the *measurement frequency*, wdyt?