### PR TITLE
Upgrade mongo plugin to use client version 2

### DIFF
--- a/bipbip.gemspec
+++ b/bipbip.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'gearman-ruby'
   s.add_runtime_dependency 'resque', '~> 1.25'
   s.add_runtime_dependency 'monit', '~> 0.3'
-  s.add_runtime_dependency 'mongo', '~> 1.10'
-  s.add_runtime_dependency 'bson_ext', '~> 1.10'
+  s.add_runtime_dependency 'mongo', '~> 2.0.5'
+  s.add_runtime_dependency 'bson', '~> 3.0.3'
   s.add_runtime_dependency 'rb-inotify', '~> 0.9.5'
   s.add_runtime_dependency 'elasticsearch', '~> 1.0.6'
 

--- a/lib/bipbip/plugin/mongodb.rb
+++ b/lib/bipbip/plugin/mongodb.rb
@@ -84,7 +84,7 @@ module Bipbip
           'hostname' => 'localhost',
           'port' => 27017,
       }.merge(config)
-      @mongodb_client ||= Mongo::Client.new([options['hostname'] + ':' + options['port'].to_s], :socket_timeout => 2)
+      @mongodb_client ||= Mongo::Client.new([options['hostname'] + ':' + options['port'].to_s], :socket_timeout => 2, :slave_ok => true)
     end
 
     # @return [Mongo::DB]

--- a/lib/bipbip/version.rb
+++ b/lib/bipbip/version.rb
@@ -1,3 +1,3 @@
 module Bipbip
-  VERSION = '0.6.1'
+  VERSION = '0.6.2'
 end


### PR DESCRIPTION
Seems the version we're using (1) might not be 100% thread safe.
I have the feeling this could be a cause for https://github.com/cargomedia/bipbip/issues/114.

@kris-lab could you update the plugin to use https://rubygems.org/gems/mongo/versions/2.0.4 ?