### PR TITLE
Let ruby handle termination signals

### DIFF
--- a/lib/bipbip/version.rb
+++ b/lib/bipbip/version.rb
@@ -1,3 +1,3 @@
 module Bipbip
-  VERSION = '0.6.3'
+  VERSION = '0.6.4'
 end

--- a/spec/bipbip/agent_spec.rb
+++ b/spec/bipbip/agent_spec.rb
@@ -32,7 +32,6 @@ describe Bipbip::Agent do
     expect(lines.select { |l| l.include?('my-plugin my-source: Data: {:foo=>12}') }.size).to be >= 2
 
     thread.exit
-    agent.interrupt
   end
 
   it 'should log plugin errors and retry' do
@@ -52,7 +51,6 @@ describe Bipbip::Agent do
     expect(lines.select { |l| l.include?('Plugin my-plugin with config {} terminated. Restarting...') }.size).to eq(0)
 
     thread.exit
-    agent.interrupt
   end
 
   it 'should log plugin timeouts and retry' do
@@ -72,7 +70,6 @@ describe Bipbip::Agent do
     expect(lines.select { |l| l.include?('Plugin my-plugin with config {} terminated. Restarting...') }.size).to eq(0)
 
     thread.exit
-    agent.interrupt
   end
 
   it 'should log plugin exceptions and restart' do
@@ -93,7 +90,6 @@ describe Bipbip::Agent do
     expect(lines.select { |l| l.include?('Plugin my-plugin with config {} terminated. Restarting...') }.size).to be >= 2
 
     thread.exit
-    agent.interrupt
   end
 
 end


### PR DESCRIPTION
@kris-lab please review

We don't need to handle signals anymore now that we use threads.
Addressing https://github.com/cargomedia/bipbip/issues/114