### PR TITLE
Monit has one item on "Exec failed" but check succeeds

### DIFF
--- a/lib/bipbip/plugin/monit.rb
+++ b/lib/bipbip/plugin/monit.rb
@@ -2,11 +2,11 @@ require 'monit'
 
 module Bipbip
   class Plugin::Monit < Plugin
-    # See https://bitbucket.org/tildeslash/monit/src/d60968cf7972cc902e5b6e2961d44456e1d9b736/src/monit.h?at=master#monit.h-145
-    STATE_FAILED = '1'
-
     # See https://bitbucket.org/tildeslash/monit/src/d60968cf7972cc902e5b6e2961d44456e1d9b736/src/monit.h?at=master#monit.h-135
-    MONITOR_NOT = '0'
+    MONITOR_NOT = 0x0
+    MONITOR_YES = 0x1
+    MONITOR_INIT = 0x2
+    MONITOR_WAITING = 0x4
 
     def metrics_schema
       [
@@ -30,7 +30,9 @@ module Bipbip
       begin
         data['Running'] = status.get ? 1 : 0
         data['All_Services_ok'] = status.services.any? do |service|
-          service.monitor == MONITOR_NOT || service.status == STATE_FAILED
+          error_flags_bitmap = service.status.to_i
+          monitor_status = service.monitor.to_i
+          (monitor_status == MONITOR_NOT) || (error_flags_bitmap != 0)
         end ? 0 : 1
       rescue
         data['Running'] = 0

--- a/lib/bipbip/version.rb
+++ b/lib/bipbip/version.rb
@@ -1,3 +1,3 @@
 module Bipbip
-  VERSION = '0.6.8'
+  VERSION = '0.6.9'
 end

--- a/spec/bipbip/plugin/monit_spec.rb
+++ b/spec/bipbip/plugin/monit_spec.rb
@@ -8,12 +8,12 @@ describe Bipbip::Plugin::Monit do
 
   it 'should collect data' do
     status_service1 = double('service1')
-    allow(status_service1).to receive(:monitor).and_return('2')
-    allow(status_service1).to receive(:status).and_return('2')
+    allow(status_service1).to receive(:monitor).and_return(Bipbip::Plugin::Monit::MONITOR_YES)
+    allow(status_service1).to receive(:status).and_return('0')
 
     status_service2 = double('service2')
-    allow(status_service2).to receive(:monitor).and_return('2')
-    allow(status_service2).to receive(:status).and_return('1')
+    allow(status_service2).to receive(:monitor).and_return(Bipbip::Plugin::Monit::MONITOR_INIT)
+    allow(status_service2).to receive(:status).and_return('4608')
 
     status = double('status')
     allow(status).to receive(:get).and_return(true)


### PR DESCRIPTION
I have this situation:
```
System 'base'                       Running
Filesystem 'root'                   Accessible
Process 'jenkins'                   Execution failed
Process 'cron'                      Running
Process 'bipbip'                    Running
```

and bipbip does not complain (aka alert)

this, on the other hand, led to an alert:
```
System 'base'                       Running
Filesystem 'root'                   Accessible
Process 'jenkins'                   Not monitored
Process 'cron'                      Running
Process 'bipbip'                    Running
```

