### PR TITLE
Plugin for coturn

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ These service plugins ship with bipbip:
 - puppet
 - command
 - socket-redis
+- coturn
 
 Please refer to [/docu/services.md](/docu/services.md) for information about the individual plugins and their configuration options.
 

--- a/docu/services.md
+++ b/docu/services.md
@@ -176,5 +176,5 @@ Configuration options:
 
 ### coturn
 Configuration options:
-- **hostname**
-- **port**
+- **hostname** (optional): Will default to `localhost`.
+- **port** (optional): Defaults to `5766`.

--- a/docu/services.md
+++ b/docu/services.md
@@ -173,3 +173,8 @@ Boolean values `true`, `false` will be replaced with `1`, `0` for both modes.
 ### socket-redis
 Configuration options:
 - **url**: URL of `socket-redis` [status](https://github.com/cargomedia/socket-redis#status-request). Defaults to `http://localhost:8085/status`
+
+### coturn
+Configuration options:
+- **hostname**
+- **port**

--- a/lib/bipbip/plugin/coturn.rb
+++ b/lib/bipbip/plugin/coturn.rb
@@ -11,18 +11,26 @@ module Bipbip
     end
 
     def monitor
+      data = _fetch_session_data
+      {
+        'total_sessions_count' => data.match(/Total sessions: (.*)/)[1].to_i,
+        'total_bitrate_outgoing' => data.scan(/ s=(\d+),/).flatten.map(&:to_i).reduce(:+) * 8,
+        'total_bitrate_incoming' => data.scan(/ r=(\d+),/).flatten.map(&:to_i).reduce(:+) * 8
+      }
+    end
+
+    private
+
+    def _fetch_session_data
       coturn = Net::Telnet.new(
         'Host' => config['hostname'] || 'localhost',
         'Port' => config['port'] || 5766
       )
-      current_sessions = coturn.cmd('ps')
+      response = coturn.cmd('ps')
       coturn.close
 
-      {
-        'total_sessions_count' => current_sessions.match(/Total sessions: (.*)/)[1].to_i,
-        'total_bitrate_outgoing' => current_sessions.scan(/ s=(\d),/).flatten.map(&:to_i).reduce(:+) * 8,
-        'total_bitrate_incoming' => current_sessions.scan(/ r=(\d),/).flatten.map(&:to_i).reduce(:+) * 8
-      }
+      response
     end
+
   end
 end

--- a/lib/bipbip/plugin/coturn.rb
+++ b/lib/bipbip/plugin/coturn.rb
@@ -4,26 +4,18 @@ module Bipbip
   class Plugin::Coturn < Plugin
     def metrics_schema
       [
-        {name : 'total_sessions_count', type : 'gauge', unit : 'Sessions'},
-        {name : 'total_users_count', type : 'gauge', unit : 'Sessions'},
-        {name : 'total_data_send', type : 'gauge', unit : 'Sessions'}
+        {name : 'total_sessions_count', type : 'gauge', unit : 'Sessions'}
       ]
     end
 
     def monitor
-      localhost = Net::Telnet::new("Host" => config['hostname'] || "localhost",
-                                   "Port" => config['port'] || 5766)
-      current_sessions = localhost.cmd("ps")
-      localhost.close
-
-      # match total sessions
-      # loop to find uniq users
-      # loop to find send data
+      coturn = Net::Telnet::new("Host" => config['hostname'] || "localhost",
+                                "Port" => config['port'] || 5766)
+      current_sessions = coturn.cmd("ps")
+      coturn.close
 
       {
-        'total_sessions_count' => 0,
-        'total_users_count' => 0,
-        'total_data_send' => 0
+        'total_sessions_count' => current_sessions.match(/Total sessions: (.*)/)[1].to_i
       }
     end
   end

--- a/lib/bipbip/plugin/coturn.rb
+++ b/lib/bipbip/plugin/coturn.rb
@@ -1,0 +1,28 @@
+require 'net/telnet'
+
+module Bipbip
+  class Plugin::Coturn < Plugin
+    def metrics_schema
+      [
+        {name : 'total_sessions_count', type : 'gauge', unit : 'Sessions'}
+      {name : 'total_users_count', type : 'gauge', unit : 'Sessions'}
+      ]
+    end
+
+    def monitor
+      localhost = Net::Telnet::new("Host" => config['hostname'] || "localhost",
+                                   "Port" => config['port'] || 5766)
+      current_sessions = localhost.cmd("ps")
+      localhost.close
+
+      # parse string
+      # match total sessions
+      # loop to find uniq users
+      # loop to find data
+
+      {
+        'sessions' => 0
+      }
+    end
+  end
+end

--- a/lib/bipbip/plugin/coturn.rb
+++ b/lib/bipbip/plugin/coturn.rb
@@ -4,8 +4,9 @@ module Bipbip
   class Plugin::Coturn < Plugin
     def metrics_schema
       [
-        {name : 'total_sessions_count', type : 'gauge', unit : 'Sessions'}
-      {name : 'total_users_count', type : 'gauge', unit : 'Sessions'}
+        {name : 'total_sessions_count', type : 'gauge', unit : 'Sessions'},
+        {name : 'total_users_count', type : 'gauge', unit : 'Sessions'},
+        {name : 'total_data_send', type : 'gauge', unit : 'Sessions'}
       ]
     end
 
@@ -15,13 +16,14 @@ module Bipbip
       current_sessions = localhost.cmd("ps")
       localhost.close
 
-      # parse string
       # match total sessions
       # loop to find uniq users
-      # loop to find data
+      # loop to find send data
 
       {
-        'sessions' => 0
+        'total_sessions_count' => 0,
+        'total_users_count' => 0,
+        'total_data_send' => 0
       }
     end
   end

--- a/lib/bipbip/plugin/coturn.rb
+++ b/lib/bipbip/plugin/coturn.rb
@@ -4,14 +4,16 @@ module Bipbip
   class Plugin::Coturn < Plugin
     def metrics_schema
       [
-        {name : 'total_sessions_count', type : 'gauge', unit : 'Sessions'}
+        { name: 'total_sessions_count', type: 'gauge', unit: 'Sessions' }
       ]
     end
 
     def monitor
-      coturn = Net::Telnet::new("Host" => config['hostname'] || "localhost",
-                                "Port" => config['port'] || 5766)
-      current_sessions = coturn.cmd("ps")
+      coturn = Net::Telnet.new(
+        'Host' => config['hostname'] || 'localhost',
+        'Port' => config['port'] || 5766
+      )
+      current_sessions = coturn.cmd('ps')
       coturn.close
 
       {

--- a/lib/bipbip/plugin/coturn.rb
+++ b/lib/bipbip/plugin/coturn.rb
@@ -4,7 +4,9 @@ module Bipbip
   class Plugin::Coturn < Plugin
     def metrics_schema
       [
-        { name: 'total_sessions_count', type: 'gauge', unit: 'Sessions' }
+        { name: 'total_sessions_count', type: 'gauge', unit: 'Sessions' },
+        { name: 'total_bitrate_outgoing', type: 'gauge', unit: 'b/s' },
+        { name: 'total_bitrate_incoming', type: 'gauge', unit: 'b/s' }
       ]
     end
 
@@ -17,7 +19,9 @@ module Bipbip
       coturn.close
 
       {
-        'total_sessions_count' => current_sessions.match(/Total sessions: (.*)/)[1].to_i
+        'total_sessions_count' => current_sessions.match(/Total sessions: (.*)/)[1].to_i,
+        'total_bitrate_outgoing' => current_sessions.scan(/ s=(\d),/).flatten.map(&:to_i).reduce(:+) * 8,
+        'total_bitrate_incoming' => current_sessions.scan(/ r=(\d),/).flatten.map(&:to_i).reduce(:+) * 8
       }
     end
   end

--- a/lib/bipbip/plugin/coturn.rb
+++ b/lib/bipbip/plugin/coturn.rb
@@ -31,6 +31,5 @@ module Bipbip
 
       response
     end
-
   end
 end

--- a/spec/bipbip/plugin/coturn_spec.rb
+++ b/spec/bipbip/plugin/coturn_spec.rb
@@ -1,0 +1,56 @@
+require 'bipbip'
+require 'bipbip/plugin/coturn'
+
+describe Bipbip::Plugin::Coturn do
+  let(:plugin) { Bipbip::Plugin::Coturn.new('coturn', { 'hostname' => 'localhost', 'port' => '5766' }, 10) }
+
+  it 'should collect turnserver sessions data' do
+    response = <<EOS
+    1) id=128000000000000076, user <njam>:
+      realm: njam.com
+    started 761 secs ago
+    expiring in 16 secs
+    client protocol UDP, relay protocol UDP
+    client addr 127.0.0.1:43176, server addr 127.0.0.1:3478
+    relay addr 127.0.0.1:61038
+    fingerprints enforced: ON
+    mobile: ON
+    usage: rp=3, rb=308, sp=3, sb=364
+    rate: r=101, s=1, total=0 (bytes per sec)
+
+    2) id=128000000000000076, user <njam>:
+      realm: njam.com
+    started 761 secs ago
+    expiring in 16 secs
+    client protocol UDP, relay protocol UDP
+    client addr 127.0.0.1:43176, server addr 127.0.0.1:3478
+    relay addr 127.0.0.1:61038
+    fingerprints enforced: ON
+    mobile: ON
+    usage: rp=3, rb=308, sp=3, sb=364
+    rate: r=98, s=98, total=0 (bytes per sec)
+
+    3) id=128000000000000076, user <njam>:
+      realm: njam.com
+    started 761 secs ago
+    expiring in 16 secs
+    client protocol UDP, relay protocol UDP
+    client addr 127.0.0.1:43176, server addr 127.0.0.1:3478
+    relay addr 127.0.0.1:61038
+    fingerprints enforced: ON
+    mobile: ON
+    usage: rp=3, rb=308, sp=3, sb=364
+    rate: r=1, s=901, total=0 (bytes per sec)
+
+    Total sessions: 3
+EOS
+
+    plugin.stub(:_fetch_session_data).and_return(response)
+
+    data = plugin.monitor
+
+    data['total_sessions_count'].should eq(3)
+    data['total_bitrate_outgoing'].should eq(1000 * 8)
+    data['total_bitrate_incoming'].should eq(200 * 8)
+  end
+end


### PR DESCRIPTION
The simplest way to watch `turnserver` it to use `telnet` connection. It listen by default like follows:
```bash
$ telnet localhost 5766
> pu

    user: <njam>, 2 sessions

  Total sessions: 2

> ps

    1) id=128000000000000076, user <njam>:
      realm: njam.com
      started 761 secs ago
      expiring in 16 secs
      client protocol UDP, relay protocol UDP
      client addr 127.0.0.1:43176, server addr 127.0.0.1:3478
      relay addr 127.0.0.1:61038
      fingerprints enforced: ON
      mobile: ON
      usage: rp=3, rb=308, sp=3, sb=364
       rate: r=0, s=0, total=0 (bytes per sec)

  Total sessions: 1

> psd /tmp/turnserver-current-session
```
