### PR TITLE
janus rtpbroadcast: add bipbip metric for "inbound packet loss"

### DIFF
--- a/lib/bipbip/plugin/janus_rtpbroadcast.rb
+++ b/lib/bipbip/plugin/janus_rtpbroadcast.rb
@@ -10,7 +10,9 @@ module Bipbip
         { name: 'streams_waiter_count', type: 'gauge', unit: 'Waiters' },
         { name: 'streams_bandwidth', type: 'gauge', unit: 'b/s' },
         { name: 'streams_zero_fps_count', type: 'gauge', unit: 'Streams' },
-        { name: 'streams_zero_bitrate_count', type: 'gauge', unit: 'Streams' }
+        { name: 'streams_zero_bitrate_count', type: 'gauge', unit: 'Streams' },
+        { name: 'streams_packet_loss_audio', type: 'gauge', unit: '%' },
+        { name: 'streams_packet_loss_video', type: 'gauge', unit: '%' }
       ]
     end
 
@@ -21,11 +23,13 @@ module Bipbip
       {
         'mountpoint_count' => mountpoints.count,
         'stream_count' => streams.count,
-        'streams_listener_count' => streams.map { |s| s['listeners'] }.reduce(0, :+),
-        'streams_waiter_count' => streams.map { |s| s['waiters'] }.reduce(0, :+),
-        'streams_bandwidth' => streams.map { |s| s['stats']['cur'] }.reduce(0, :+),
+        'streams_listener_count' => streams.map { |s| s['webrtc-endpoint']['listeners'] }.reduce(0, :+),
+        'streams_waiter_count' => streams.map { |s| s['webrtc-endpoint']['waiters'] }.reduce(0, :+),
+        'streams_bandwidth' => streams.map { |s| s['stats']['video']['bitrate'] + s['stats']['audio']['bitrate'] }.reduce(0, :+),
         'streams_zero_fps_count' => streams.count { |s| s['frame']['fps'] == 0 },
-        'streams_zero_bitrate_count' => streams.count { |s| s['stats']['cur'] == 0 }
+        'streams_zero_bitrate_count' => streams.count { |s| s['stats']['video']['bitrate'] == 0 || s['stats']['audio']['bitrate'] == 0 },
+        'streams_packet_loss_audio' => streams.map { |s| s['stats']['audio']['packet-loss'] }.reduce(0, :+),
+        'streams_packet_loss_video' => streams.map { |s| s['stats']['video']['packet-loss'] }.reduce(0, :+)
       }
     end
 

--- a/lib/bipbip/plugin/janus_rtpbroadcast.rb
+++ b/lib/bipbip/plugin/janus_rtpbroadcast.rb
@@ -34,10 +34,10 @@ module Bipbip
         'streams_bandwidth' => streams.map { |s| s['stats']['video']['bitrate'] + s['stats']['audio']['bitrate'] }.reduce(0, :+),
         'streams_zero_fps_count' => streams.count { |s| s['frame']['fps'] == 0 },
         'streams_zero_bitrate_count' => streams.count { |s| s['stats']['video']['bitrate'] == 0 || s['stats']['audio']['bitrate'] == 0 },
-        'streams_packet_loss_audio_max' => streams.map { |s| s['stats']['audio']['packet-loss'] }.max,
-        'streams_packet_loss_audio_avg' => packet_loss_audio_avg,
-        'streams_packet_loss_video_max' => streams.map { |s| s['stats']['video']['packet-loss'] }.max,
-        'streams_packet_loss_video_avg' => packet_loss_video_avg
+        'streams_packet_loss_audio_max' => streams.map { |s| s['stats']['audio']['packet-loss'] * 100 }.max,
+        'streams_packet_loss_audio_avg' => packet_loss_audio_avg * 100,
+        'streams_packet_loss_video_max' => streams.map { |s| s['stats']['video']['packet-loss'] * 100 }.max,
+        'streams_packet_loss_video_avg' => packet_loss_video_avg * 100
       }
     end
 

--- a/lib/bipbip/version.rb
+++ b/lib/bipbip/version.rb
@@ -1,3 +1,3 @@
 module Bipbip
-  VERSION = '0.6.17'.freeze
+  VERSION = '0.6.18'.freeze
 end

--- a/lib/bipbip/version.rb
+++ b/lib/bipbip/version.rb
@@ -1,3 +1,3 @@
 module Bipbip
-  VERSION = '0.6.16'.freeze
+  VERSION = '0.6.17'.freeze
 end

--- a/spec/bipbip/plugin/janus_rtpbroadcast_spec.rb
+++ b/spec/bipbip/plugin/janus_rtpbroadcast_spec.rb
@@ -108,10 +108,10 @@ EOS
     data['streams_bandwidth'].should eq(65)
     data['streams_zero_fps_count'].should eq(1)
     data['streams_zero_bitrate_count'].should eq(1)
-    data['streams_packet_loss_audio_max'].should eq(0.9)
-    data['streams_packet_loss_audio_avg'].should eq(0.6)
-    data['streams_packet_loss_video_max'].should eq(0.4)
-    data['streams_packet_loss_video_avg'].should eq(0.2)
+    data['streams_packet_loss_audio_max'].should eq(90)
+    data['streams_packet_loss_audio_avg'].should eq(60)
+    data['streams_packet_loss_video_max'].should eq(40)
+    data['streams_packet_loss_video_avg'].should eq(20)
   end
 
   it 'should handle empty list of mountpoints' do

--- a/spec/bipbip/plugin/janus_rtpbroadcast_spec.rb
+++ b/spec/bipbip/plugin/janus_rtpbroadcast_spec.rb
@@ -85,7 +85,7 @@ describe Bipbip::Plugin::JanusRtpbroadcast do
             "webrtc-endpoint": {"listeners": 200, "waiters": 100},
             "stats": {
                 "audio": {"packet-loss": 0.5, "bitrate": 10},
-                "video": {"packet-loss": 0.1, "bitrate": 40}
+                "video": {"packet-loss": 0.2, "bitrate": 40}
             },
             "frame": {"width": 0, "height": 0, "fps": 50, "key-distance": 50},
             "session": {"webrtc-active": 0, "autoswitch-enabled": 1, "remb-avg": 0}
@@ -108,8 +108,10 @@ EOS
     data['streams_bandwidth'].should eq(65)
     data['streams_zero_fps_count'].should eq(1)
     data['streams_zero_bitrate_count'].should eq(1)
-    data['streams_packet_loss_audio'].should eq(2.4)
-    data['streams_packet_loss_video'].should eq(0.7)
+    data['streams_packet_loss_audio_max'].should eq(0.9)
+    data['streams_packet_loss_audio_avg'].should eq(0.6)
+    data['streams_packet_loss_video_max'].should eq(0.4)
+    data['streams_packet_loss_video_avg'].should eq(0.2)
   end
 
   it 'should handle empty list of mountpoints' do

--- a/spec/bipbip/plugin/janus_rtpbroadcast_spec.rb
+++ b/spec/bipbip/plugin/janus_rtpbroadcast_spec.rb
@@ -13,39 +13,55 @@ describe Bipbip::Plugin::JanusRtpbroadcast do
     "list": [
       {
         "id": "1",
+        "uid": "4da7fe6edf6828474300c5d5f7074284",
         "name": "1",
         "description": "Opus/VP8 tester.py test stream",
         "streams": [
           {
             "id": "1",
+            "uid": "4da7fe6edf6828474300c5d5f7074284",
             "index": 1,
-            "audioport": 8784,
-            "videoport": 8504,
-            "listeners": 32,
-            "waiters": 4,
-            "stats": {"min": 0.0, "max": 10.0, "cur": 5.0, "avg": 5.0},
+            "rtp-endpoint": {
+                "audio": {"host": "127.0.0.1","port": 8139},
+                "video": {"host": "127.0.0.1", "port": 8888}
+            },
+            "webrtc-endpoint": {"listeners": 32, "waiters": 4},
+            "stats": {
+                "audio": {"packet-loss": 0.1, "bitrate": 1},
+                "video": {"packet-loss": 0.4, "bitrate": 4}
+            },
             "frame": {"width": 0, "height": 0, "fps": 10, "key-distance": 20},
             "session": {"webrtc-active": 0, "autoswitch-enabled": 1, "remb-avg": 0}
           },
           {
             "id": "1",
+            "uid": "4da7fe6edf6828474300c5d5f7074284",
             "index": 2,
-            "audioport": 8018,
-            "videoport": 8624,
-            "listeners": 0,
-            "waiters": 12,
-            "stats": {"min": 0.0, "max": 20.0, "cur": 10.0, "avg": 10.0},
+            "rtp-endpoint": {
+                "audio": {"host": "127.0.0.1","port": 8018},
+                "video": {"host": "127.0.0.1", "port": 8624}
+            },
+            "webrtc-endpoint": {"listeners": 0, "waiters": 12},
+            "stats": {
+                "audio": {"packet-loss": 0.9, "bitrate": 3},
+                "video": {"packet-loss": 0.1, "bitrate": 7}
+            },
             "frame": {"width": 0, "height": 0, "fps": 30, "key-distance": 30},
             "session": {"webrtc-active": 0, "autoswitch-enabled": 1, "remb-avg": 0}
           },
           {
             "id": "1",
+            "uid": "4da7fe6edf6828474300c5d5f7074284",
             "index": 3,
-            "audioport": 8312,
-            "videoport": 8267,
-            "listeners": 88,
-            "waiters": 12,
-            "stats": {"min": 0.0, "max": 0.0, "cur": 0.0, "avg": 0.0},
+            "rtp-endpoint": {
+                "audio": {"host": "127.0.0.1","port": 8312},
+                "video": {"host": "127.0.0.1", "port": 8267}
+            },
+            "webrtc-endpoint": {"listeners": 88, "waiters": 12},
+            "stats": {
+                "audio": {"packet-loss": 0.9, "bitrate": 0},
+                "video": {"packet-loss": 0.1, "bitrate": 0}
+            },
             "frame": {"width": 0, "height": 0, "fps": 0, "key-distance": 40},
             "session": {"webrtc-active": 0, "autoswitch-enabled": 1, "remb-avg": 0
             }
@@ -54,17 +70,23 @@ describe Bipbip::Plugin::JanusRtpbroadcast do
       },
       {
         "id": "2",
+        "uid": "ABCDEF6edf6828474300c5d5f7074284",
         "name": "2",
         "description": "Opus/VP8 tester.py test stream",
         "streams": [
           {
             "id": "2",
+            "uid": "ABCDEF6edf6828474300c5d5f7074284",
             "index": 1,
-            "audioport": 9784,
-            "videoport": 9504,
-            "listeners": 200,
-            "waiters": 100,
-            "stats": {"min": 0.0, "max": 100.0, "cur": 50.0, "avg": 50.0},
+            "rtp-endpoint": {
+                "audio": {"host": "127.0.0.1","port": 9784},
+                "video": {"host": "127.0.0.1", "port": 9504}
+            },
+            "webrtc-endpoint": {"listeners": 200, "waiters": 100},
+            "stats": {
+                "audio": {"packet-loss": 0.5, "bitrate": 10},
+                "video": {"packet-loss": 0.1, "bitrate": 40}
+            },
             "frame": {"width": 0, "height": 0, "fps": 50, "key-distance": 50},
             "session": {"webrtc-active": 0, "autoswitch-enabled": 1, "remb-avg": 0}
           }
@@ -86,6 +108,8 @@ EOS
     data['streams_bandwidth'].should eq(65)
     data['streams_zero_fps_count'].should eq(1)
     data['streams_zero_bitrate_count'].should eq(1)
+    data['streams_packet_loss_audio'].should eq(2.4)
+    data['streams_packet_loss_video'].should eq(0.7)
   end
 
   it 'should handle empty list of mountpoints' do


### PR DESCRIPTION
Depends on cargomedia/janus-gateway-rtpbroadcast#81
Depends on https://github.com/cargomedia/janus-gateway-rtpbroadcast/pull/46
Depends on https://github.com/cargomedia/janus-gateway-rtpbroadcast/pull/82

> And maybe also for "keyframe-overdue" (to replace the logparser entry)?