### PR TITLE
Handle telnet timeout exception for coturn

### DIFF
--- a/lib/bipbip/plugin/coturn.rb
+++ b/lib/bipbip/plugin/coturn.rb
@@ -12,11 +12,18 @@ module Bipbip
 
     def monitor
       data = _fetch_session_data
-      {
-        'total_sessions_count' => (data.scan(/Total sessions: (\d+)$/).flatten.map(&:to_i).reduce(:+) || 0),
-        'total_bitrate_outgoing' => (data.scan(/ s=(\d+),/).flatten.map(&:to_i).reduce(:+) || 0) * 8,
-        'total_bitrate_incoming' => (data.scan(/ r=(\d+),/).flatten.map(&:to_i).reduce(:+) || 0) * 8
-      }
+
+      begin
+        metrics_data = {
+          'total_sessions_count' => data.match(/Total sessions: (.*)/)[1].to_i,
+          'total_bitrate_outgoing' => (data.scan(/ s=(\d+),/).flatten.map(&:to_i).reduce(:+) || 0) * 8,
+          'total_bitrate_incoming' => (data.scan(/ r=(\d+),/).flatten.map(&:to_i).reduce(:+) || 0) * 8
+        }
+      rescue => e
+        raise("Cannot prepare metrics for malformed response: `#{data}`. Error: `#{e.message}`")
+      end
+
+      metrics_data
     end
 
     private

--- a/lib/bipbip/plugin/coturn.rb
+++ b/lib/bipbip/plugin/coturn.rb
@@ -26,7 +26,9 @@ module Bipbip
         'Host' => config['hostname'] || 'localhost',
         'Port' => config['port'] || 5766
       )
+      response = coturn.cmd('ps')
       coturn.close
+
       response
     end
   end

--- a/lib/bipbip/plugin/coturn.rb
+++ b/lib/bipbip/plugin/coturn.rb
@@ -13,7 +13,7 @@ module Bipbip
     def monitor
       data = _fetch_session_data
       {
-        'total_sessions_count' => data.match(/Total sessions: (.*)/)[1].to_i,
+        'total_sessions_count' => (data.scan(/Total sessions: (\d+)$/).flatten.map(&:to_i).reduce(:+) || 0),
         'total_bitrate_outgoing' => (data.scan(/ s=(\d+),/).flatten.map(&:to_i).reduce(:+) || 0) * 8,
         'total_bitrate_incoming' => (data.scan(/ r=(\d+),/).flatten.map(&:to_i).reduce(:+) || 0) * 8
       }
@@ -26,19 +26,7 @@ module Bipbip
         'Host' => config['hostname'] || 'localhost',
         'Port' => config['port'] || 5766
       )
-
-      begin
-        response = coturn.cmd('ps')
-      rescue Net::OpenTimeout => e
-        raise("Cannot open connection to `coturn`. Error: `#{e.message}`")
-      rescue Net::ReadTimeout => e
-        raise("Cannot read data from `coturn`. Error: `#{e.message}`")
-      rescue => e
-        raise("Cannot query data from `coturn`. Error: `#{e.message}`")
-      end
-
       coturn.close
-
       response
     end
   end

--- a/lib/bipbip/plugin/coturn.rb
+++ b/lib/bipbip/plugin/coturn.rb
@@ -26,7 +26,17 @@ module Bipbip
         'Host' => config['hostname'] || 'localhost',
         'Port' => config['port'] || 5766
       )
-      response = coturn.cmd('ps')
+
+      begin
+        response = coturn.cmd('ps')
+      rescue Net::OpenTimeout => e
+        raise("Cannot open connection to `coturn`. Error: `#{e.message}`")
+      rescue Net::ReadTimeout => e
+        raise("Cannot read data from `coturn`. Error: `#{e.message}`")
+      rescue => e
+        raise("Cannot query data from `coturn`. Error: `#{e.message}`")
+      end
+
       coturn.close
 
       response

--- a/lib/bipbip/version.rb
+++ b/lib/bipbip/version.rb
@@ -1,3 +1,3 @@
 module Bipbip
-  VERSION = '0.6.17'.freeze
+  VERSION = '0.6.18'.freeze
 end

--- a/spec/bipbip/plugin/coturn_spec.rb
+++ b/spec/bipbip/plugin/coturn_spec.rb
@@ -69,7 +69,7 @@ EOS
     data['total_bitrate_incoming'].should eq(200 * 8)
   end
 
-  it 'should collect data for malformed response' do
+  it 'should raise error for malformed response' do
     response = <<EOS
     TURN Server
     Coturn-4.5.0.3 'dan Eider'
@@ -80,10 +80,6 @@ EOS
 
     plugin.stub(:_fetch_session_data).and_return(response)
 
-    data = plugin.monitor
-
-    data['total_sessions_count'].should eq(0)
-    data['total_bitrate_outgoing'].should eq(0)
-    data['total_bitrate_incoming'].should eq(0)
+    expect { plugin.monitor }.to raise_error(/Cannot prepare metrics for malformed response:/)
   end
 end

--- a/spec/bipbip/plugin/coturn_spec.rb
+++ b/spec/bipbip/plugin/coturn_spec.rb
@@ -68,4 +68,22 @@ EOS
     data['total_bitrate_outgoing'].should eq(1000 * 8)
     data['total_bitrate_incoming'].should eq(200 * 8)
   end
+
+  it 'should collect data for malformed response' do
+    response = <<EOS
+    TURN Server
+    Coturn-4.5.0.3 'dan Eider'
+
+    Type '?' for help
+    >
+EOS
+
+    plugin.stub(:_fetch_session_data).and_return(response)
+
+    data = plugin.monitor
+
+    data['total_sessions_count'].should eq(0)
+    data['total_bitrate_outgoing'].should eq(0)
+    data['total_bitrate_incoming'].should eq(0)
+  end
 end


### PR DESCRIPTION
Part of https://github.com/cargomedia/puppet-cargomedia/issues/1147

```
E, [2016-04-11T06:40:21.624609 #14960] ERROR -- coturn janus2.fuckbook.com::coturn::localhost: undefined method `[]' for nil:NilClass
 /var/lib/gems/1.9.1/gems/bipbip-0.6.16/lib/bipbip/plugin/coturn.rb:16:in `monitor'
 /var/lib/gems/1.9.1/gems/bipbip-0.6.16/lib/bipbip/plugin.rb:80:in `run_measurement'
 /var/lib/gems/1.9.1/gems/bipbip-0.6.16/lib/bipbip/plugin.rb:39:in `block (2 levels) in run'
 /usr/lib/ruby/1.9.1/timeout.rb:68:in `timeout'
 /var/lib/gems/1.9.1/gems/bipbip-0.6.16/lib/bipbip/plugin.rb:38:in `block in run'
 /var/lib/gems/1.9.1/gems/bipbip-0.6.16/lib/bipbip/plugin.rb:36:in `loop'
 /var/lib/gems/1.9.1/gems/bipbip-0.6.16/lib/bipbip/plugin.rb:36:in `run'
 /var/lib/gems/1.9.1/gems/bipbip-0.6.16/lib/bipbip/agent.rb:59:in `block in start_plugin'
```