### PR TITLE
janus-gateway-rtpbroadcast plugin fails

### DIFF
--- a/lib/bipbip/plugin/janus_rtpbroadcast.rb
+++ b/lib/bipbip/plugin/janus_rtpbroadcast.rb
@@ -23,20 +23,20 @@ module Bipbip
       mountpoints = data['data']['list']
       streams = mountpoints.map { |mp| mp['streams'] }.flatten
 
-      packet_loss_audio_avg = streams.count != 0 ? streams.map { |s| s['stats']['audio']['packet-loss'] }.reduce(0, :+) / streams.count : 0
-      packet_loss_video_avg = streams.count != 0 ? streams.map { |s| s['stats']['video']['packet-loss'] }.reduce(0, :+) / streams.count : 0
+      packet_loss_audio_avg = streams.count != 0 ? streams.map { |s| s['stats']['audio']['packet-loss'] || 0 }.reduce(0, :+) / streams.count : 0
+      packet_loss_video_avg = streams.count != 0 ? streams.map { |s| s['stats']['video']['packet-loss'] || 0 }.reduce(0, :+) / streams.count : 0
 
       {
         'mountpoint_count' => mountpoints.count,
         'stream_count' => streams.count,
         'streams_listener_count' => streams.map { |s| s['webrtc-endpoint']['listeners'] }.reduce(0, :+),
         'streams_waiter_count' => streams.map { |s| s['webrtc-endpoint']['waiters'] }.reduce(0, :+),
-        'streams_bandwidth' => streams.map { |s| s['stats']['video']['bitrate'] + s['stats']['audio']['bitrate'] }.reduce(0, :+),
+        'streams_bandwidth' => streams.map { |s| (s['stats']['video']['bitrate'] || 0) + (s['stats']['audio']['bitrate'] || 0) }.reduce(0, :+),
         'streams_zero_fps_count' => streams.count { |s| s['frame']['fps'] == 0 },
-        'streams_zero_bitrate_count' => streams.count { |s| s['stats']['video']['bitrate'] == 0 || s['stats']['audio']['bitrate'] == 0 },
-        'streams_packet_loss_audio_max' => streams.map { |s| s['stats']['audio']['packet-loss'] * 100 }.max,
+        'streams_zero_bitrate_count' => streams.count { |s| s['stats']['video']['bitrate'].nil? || s['stats']['video']['bitrate'] == 0  },
+        'streams_packet_loss_audio_max' => streams.map { |s| (s['stats']['audio']['packet-loss'] || 0) * 100 }.max,
         'streams_packet_loss_audio_avg' => packet_loss_audio_avg * 100,
-        'streams_packet_loss_video_max' => streams.map { |s| s['stats']['video']['packet-loss'] * 100 }.max,
+        'streams_packet_loss_video_max' => streams.map { |s| (s['stats']['video']['packet-loss'] || 0) * 100 }.max,
         'streams_packet_loss_video_avg' => packet_loss_video_avg * 100
       }
     end

--- a/lib/bipbip/plugin/janus_rtpbroadcast.rb
+++ b/lib/bipbip/plugin/janus_rtpbroadcast.rb
@@ -33,7 +33,7 @@ module Bipbip
         'streams_waiter_count' => streams.map { |s| s['webrtc-endpoint']['waiters'] }.reduce(0, :+),
         'streams_bandwidth' => streams.map { |s| (s['stats']['video']['bitrate'] || 0) + (s['stats']['audio']['bitrate'] || 0) }.reduce(0, :+),
         'streams_zero_fps_count' => streams.count { |s| s['frame']['fps'] == 0 },
-        'streams_zero_bitrate_count' => streams.count { |s| s['stats']['video']['bitrate'].nil? || s['stats']['video']['bitrate'] == 0  },
+        'streams_zero_bitrate_count' => streams.count { |s| s['stats']['video']['bitrate'].nil? || s['stats']['video']['bitrate'] == 0 },
         'streams_packet_loss_audio_max' => streams.map { |s| (s['stats']['audio']['packet-loss'] || 0) * 100 }.max,
         'streams_packet_loss_audio_avg' => packet_loss_audio_avg * 100,
         'streams_packet_loss_video_max' => streams.map { |s| (s['stats']['video']['packet-loss'] || 0) * 100 }.max,

--- a/lib/bipbip/version.rb
+++ b/lib/bipbip/version.rb
@@ -1,3 +1,3 @@
 module Bipbip
-  VERSION = '0.6.19'.freeze
+  VERSION = '0.6.20'.freeze
 end

--- a/spec/bipbip/plugin/janus_rtpbroadcast_spec.rb
+++ b/spec/bipbip/plugin/janus_rtpbroadcast_spec.rb
@@ -137,4 +137,56 @@ EOS
     data['streams_zero_fps_count'].should eq(0)
     data['streams_zero_bitrate_count'].should eq(0)
   end
+
+  it 'should handle null values in responses' do
+    response = <<EOS
+{
+  "plugin": "janus.plugin.cm.rtpbroadcast",
+  "data": {
+    "streaming": "list",
+    "list": [
+      {
+        "id": "0",
+        "uid": "XXXXXX6edf6828474300c5d5f7074284",
+        "name": "0",
+        "description": "Opus/VP8 tester.py test stream",
+        "streams": [
+          {
+            "id": "2",
+            "uid": "XXXXXX6edf6828474300c5d5f7074284",
+            "index": 1,
+            "rtp-endpoint": {
+                "audio": {"host": "127.0.0.1","port": 9784},
+                "video": {"host": "127.0.0.1", "port": 9504}
+            },
+            "webrtc-endpoint": {"listeners": 200, "waiters": 100},
+            "stats": {
+                "audio": {"packet-loss": null, "bitrate": null},
+                "video": {"packet-loss": null, "bitrate": null}
+            },
+            "frame": {"width": 0, "height": 0, "fps": 50, "key-distance": 50},
+            "session": {"webrtc-active": 0, "autoswitch-enabled": 1, "remb-avg": null }
+          }
+        ]
+      }
+    ]
+  }
+}
+EOS
+
+    plugin.stub(:_fetch_data).and_return(JSON.parse(response))
+
+    data = plugin.monitor
+
+    data['mountpoint_count'].should eq(1)
+    data['stream_count'].should eq(1)
+    data['streams_listener_count'].should eq(200)
+    data['streams_waiter_count'].should eq(100)
+    data['streams_bandwidth'].should eq(0)
+    data['streams_zero_bitrate_count'].should eq(1)
+    data['streams_packet_loss_audio_max'].should eq(0)
+    data['streams_packet_loss_audio_avg'].should eq(0)
+    data['streams_packet_loss_video_max'].should eq(0)
+    data['streams_packet_loss_video_avg'].should eq(0)
+  end
 end


### PR DESCRIPTION
```
E, [2016-04-26T10:05:46.115341 #12049] ERROR -- janus-rtpbroadcast janus2.fuckbook.com::janus-rtpbroadcast::http___127_0_0_1_8300_janus: nil can't be coerced into Fixnum
 /var/lib/gems/1.9.1/gems/bipbip-0.6.19/lib/bipbip/plugin/janus_rtpbroadcast.rb:26:in `+'
 /var/lib/gems/1.9.1/gems/bipbip-0.6.19/lib/bipbip/plugin/janus_rtpbroadcast.rb:26:in `each'
 /var/lib/gems/1.9.1/gems/bipbip-0.6.19/lib/bipbip/plugin/janus_rtpbroadcast.rb:26:in `reduce'
 /var/lib/gems/1.9.1/gems/bipbip-0.6.19/lib/bipbip/plugin/janus_rtpbroadcast.rb:26:in `monitor'
 /var/lib/gems/1.9.1/gems/bipbip-0.6.19/lib/bipbip/plugin.rb:80:in `run_measurement'
 /var/lib/gems/1.9.1/gems/bipbip-0.6.19/lib/bipbip/plugin.rb:39:in `block (2 levels) in run'
 /usr/lib/ruby/1.9.1/timeout.rb:68:in `timeout'
 /var/lib/gems/1.9.1/gems/bipbip-0.6.19/lib/bipbip/plugin.rb:38:in `block in run'
 /var/lib/gems/1.9.1/gems/bipbip-0.6.19/lib/bipbip/plugin.rb:36:in `loop'
 /var/lib/gems/1.9.1/gems/bipbip-0.6.19/lib/bipbip/plugin.rb:36:in `run'
 /var/lib/gems/1.9.1/gems/bipbip-0.6.19/lib/bipbip/agent.rb:59:in `block in start_plugin'
```

```
E, [2016-04-26T10:15:46.705083 #12049] ERROR -- janus-rtpbroadcast janus2.fuckbook.com::janus-rtpbroadcast::http___127_0_0_1_8300_janus: undefined method `[]' for nil:NilClass
 /var/lib/gems/1.9.1/gems/bipbip-0.6.19/lib/bipbip/plugin/janus_rtpbroadcast.rb:23:in `monitor'
 /var/lib/gems/1.9.1/gems/bipbip-0.6.19/lib/bipbip/plugin.rb:80:in `run_measurement'
 /var/lib/gems/1.9.1/gems/bipbip-0.6.19/lib/bipbip/plugin.rb:39:in `block (2 levels) in run'
 /usr/lib/ruby/1.9.1/timeout.rb:68:in `timeout'
 /var/lib/gems/1.9.1/gems/bipbip-0.6.19/lib/bipbip/plugin.rb:38:in `block in run'
 /var/lib/gems/1.9.1/gems/bipbip-0.6.19/lib/bipbip/plugin.rb:36:in `loop'
 /var/lib/gems/1.9.1/gems/bipbip-0.6.19/lib/bipbip/plugin.rb:36:in `run'
 /var/lib/gems/1.9.1/gems/bipbip-0.6.19/lib/bipbip/agent.rb:59:in `block in start_plugin'
```