### PR TITLE
Add netstat error statistics

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,3 +8,6 @@ Style/Documentation:
 
 Style/MultilineBlockChain:
   Enabled: false
+
+Performance/PushSplat:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,5 +9,9 @@ Style/Documentation:
 Style/MultilineBlockChain:
   Enabled: false
 
+Style/MutableConstant:
+  Exclude:
+    - lib/bipbip/version.rb
+
 Performance/PushSplat:
   Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: ruby
 sudo: false
 
 rvm:
+  - 2.2
+  - 2.1
   - 2.0.0
   - 1.9.3
 
@@ -12,3 +14,7 @@ services:
 
 notifications:
   email: false
+
+# to avoid travis-ci issue since 2015-12-25
+before_install:
+  - gem update bundler

--- a/docu/services.md
+++ b/docu/services.md
@@ -47,7 +47,8 @@ Configuration options:
 - **url**: URL of nginx' [stub_status](http://nginx.org/en/docs/http/ngx_http_stub_status_module.html) (e.g. `http://localhost:80/server-status`).
 
 ### network
-No configuration necessary.
+Configuration options:
+- **interfaces** (optional): List of network interfaces to observe (e.g. ['eth0', 'eth1']).
 
 ### monit
 Configuration options:

--- a/docu/services.md
+++ b/docu/services.md
@@ -48,7 +48,7 @@ Configuration options:
 
 ### network
 Configuration options:
-- **interfaces** (optional): List of network interfaces to observe (e.g. ['eth0', 'eth1']).
+- **exclude_interfaces** (optional): Regex list of network interfaces to exclude (Default: `[ /lo/, /bond/, /vboxnet/ ]`).
 
 ### monit
 Configuration options:

--- a/lib/bipbip/plugin/network.rb
+++ b/lib/bipbip/plugin/network.rb
@@ -1,38 +1,43 @@
 module Bipbip
   class Plugin::Network < Plugin
     def metrics_schema
-      metrics = [{ name: 'connections_total', type: 'gauge', unit: 'Connections' }]
-      _interfaces.each do |interface|
-        _errors.each do |e|
-          metrics <<
-            { name: "#{interface}_#{e}", type: 'gauge' }
-        end
-      end
-      metrics
+      [
+        { name: 'connections_total', type: 'gauge', unit: 'Connections' },
+        { name: 'rx_errors', type: 'counter' },
+        { name: 'rx_dropped', type: 'counter' },
+        { name: 'tx_errors', type: 'counter' },
+        { name: 'tx_dropped', type: 'counter' }
+      ]
     end
 
     def monitor
       tcp_summary = `ss -s | grep '^TCP:'`
       tcp_counters = /^TCP:\s+(\d+) \(estab (\d+), closed (\d+), orphaned (\d+), synrecv (\d+), timewait (\d+)\/(\d+)\), ports (\d+)$/.match(tcp_summary)
       raise "Cannot match ss-output `#{tcp_summary}`" unless tcp_counters
-      data = {}
-      data['connections_total'] = tcp_counters[1].to_i
-      _interfaces.each do |interface|
-        _errors.each do |e|
-          data["#{interface}_#{e}"] = File.read("/sys/class/net/#{interface}/statistics/#{e}".chomp).to_i
-        end
-      end
-      data
+      {
+        'connections_total' => tcp_counters[1].to_i,
+        'rx_errors' => _statistics_sum('rx_errors'),
+        'rx_dropped' => _statistics_sum('rx_dropped'),
+        'tx_errors' => _statistics_sum('tx_errors'),
+        'tx_dropped' => _statistics_sum('tx_dropped')
+      }
     end
 
     private
 
-    def _errors
-      %w(rx_errors rx_dropped tx_errors tx_dropped)
+    # @param [String] check
+    # @return [Integer] Sum of readings for all interfaces
+    def _statistics_sum(check)
+      _interfaces.reduce(0) do |memo, interface|
+        memo + File.read("/sys/class/net/#{interface}/statistics/#{check}".chomp).to_i
+      end
     end
 
+    # @return [Array] List of all network interfaces to monitor
     def _interfaces
-      config['interfaces'] || []
+      interfaces_excluded = config['exclude_interfaces'] || [/lo/, /bond/, /vboxnet/]
+      interfaces_found = `ls /sys/class/net/`.split(/\n/)
+      interfaces_found.reject { |i| i.match(Regexp.union(interfaces_excluded)) }
     end
   end
 end

--- a/lib/bipbip/plugin/network.rb
+++ b/lib/bipbip/plugin/network.rb
@@ -1,17 +1,38 @@
 module Bipbip
   class Plugin::Network < Plugin
     def metrics_schema
-      [
-        { name: 'connections_total', type: 'gauge', unit: 'Connections' }
-      ]
+      metrics = [{ name: 'connections_total', type: 'gauge', unit: 'Connections' }]
+      _interfaces.each do |interface|
+        _errors.each do |e|
+          metrics <<
+              { name: "#{interface}_#{e}", type: 'gauge' }
+        end
+      end
+      metrics
     end
 
     def monitor
       tcp_summary = `ss -s | grep '^TCP:'`
       tcp_counters = /^TCP:\s+(\d+) \(estab (\d+), closed (\d+), orphaned (\d+), synrecv (\d+), timewait (\d+)\/(\d+)\), ports (\d+)$/.match(tcp_summary)
       raise "Cannot match ss-output `#{tcp_summary}`" unless tcp_counters
+      data = {}
+      data['connections_total'] = tcp_counters[1].to_i
+      _interfaces.each do |interface|
+        _errors.each do |e|
+          data["#{interface}_#{e}"] = File.read("/sys/class/net/#{interface}/statistics/#{e}".chomp).to_i
+        end
+      end
+      data
+    end
 
-      { connections_total: tcp_counters[1].to_i }
+    private
+
+    def _errors
+      %w(rx_errors rx_dropped tx_errors tx_dropped)
+    end
+
+    def _interfaces
+      config['interfaces'] || []
     end
   end
 end

--- a/lib/bipbip/plugin/network.rb
+++ b/lib/bipbip/plugin/network.rb
@@ -5,7 +5,7 @@ module Bipbip
       _interfaces.each do |interface|
         _errors.each do |e|
           metrics <<
-              { name: "#{interface}_#{e}", type: 'gauge' }
+            { name: "#{interface}_#{e}", type: 'gauge' }
         end
       end
       metrics

--- a/lib/bipbip/plugin/network.rb
+++ b/lib/bipbip/plugin/network.rb
@@ -3,10 +3,10 @@ module Bipbip
     def metrics_schema
       [
         { name: 'connections_total', type: 'gauge', unit: 'Connections' },
-        { name: 'rx_errors', type: 'counter' },
-        { name: 'rx_dropped', type: 'counter' },
-        { name: 'tx_errors', type: 'counter' },
-        { name: 'tx_dropped', type: 'counter' }
+        { name: 'rx_errors', type: 'counter', unit: 'Errors' },
+        { name: 'rx_dropped', type: 'counter', unit: 'Packets' },
+        { name: 'tx_errors', type: 'counter', unit: 'Errors' },
+        { name: 'tx_dropped', type: 'counter', unit: 'Packets' }
       ]
     end
 

--- a/lib/bipbip/version.rb
+++ b/lib/bipbip/version.rb
@@ -1,3 +1,3 @@
 module Bipbip
-  VERSION = '0.6.21'.freeze
+  VERSION = '0.6.21'
 end

--- a/lib/bipbip/version.rb
+++ b/lib/bipbip/version.rb
@@ -1,3 +1,3 @@
 module Bipbip
-  VERSION = '0.6.21'
+  VERSION = '0.6.22'
 end

--- a/spec/bipbip/plugin/log_parser_spec.rb
+++ b/spec/bipbip/plugin/log_parser_spec.rb
@@ -95,7 +95,7 @@ describe Bipbip::Plugin::LogParser do
   end
 
   it 'should raise if unable to read file' do
-    file.chmod(0000)
+    file.chmod(0o0)
     expect { plugin.monitor }.to raise_error(RuntimeError, /Cannot read file/)
   end
 end

--- a/spec/bipbip/plugin/network_spec.rb
+++ b/spec/bipbip/plugin/network_spec.rb
@@ -2,15 +2,15 @@ require 'bipbip'
 require 'bipbip/plugin/network'
 
 describe Bipbip::Plugin::Network do
-  let(:plugin1) { Bipbip::Plugin::Network.new('network', { 'interfaces' => ['eth0'] }, 10) }
+  let(:plugin1) { Bipbip::Plugin::Network.new('network', { exclude_interfaces: false }, 10) }
 
   it 'should collect data' do
     data = plugin1.monitor
 
     data['connections_total'].should be_instance_of(Fixnum)
-    data['eth0_rx_errors'].should be_instance_of(Fixnum)
-    data['eth0_rx_dropped'].should be_instance_of(Fixnum)
-    data['eth0_tx_errors'].should be_instance_of(Fixnum)
-    data['eth0_tx_dropped'].should be_instance_of(Fixnum)
+    data['rx_errors'].should be_instance_of(Fixnum)
+    data['rx_dropped'].should be_instance_of(Fixnum)
+    data['tx_errors'].should be_instance_of(Fixnum)
+    data['tx_dropped'].should be_instance_of(Fixnum)
   end
 end

--- a/spec/bipbip/plugin/network_spec.rb
+++ b/spec/bipbip/plugin/network_spec.rb
@@ -1,0 +1,16 @@
+require 'bipbip'
+require 'bipbip/plugin/network'
+
+describe Bipbip::Plugin::Network do
+  let(:plugin1) { Bipbip::Plugin::Network.new('network', { 'interfaces' => ['eth0'] }, 10) }
+
+  it 'should collect data' do
+    data = plugin1.monitor
+
+    data['connections_total'].should be_instance_of(Fixnum)
+    data['eth0_rx_errors'].should be_instance_of(Fixnum)
+    data['eth0_rx_dropped'].should be_instance_of(Fixnum)
+    data['eth0_tx_errors'].should be_instance_of(Fixnum)
+    data['eth0_tx_dropped'].should be_instance_of(Fixnum)
+  end
+end


### PR DESCRIPTION
```
netstat --statistics
```

E.g. `SndbufErrors` and `RcvbufErrors`.
They only show up if present.

```
[…]
Ip:
    49942134 total packets received
    890 with invalid addresses
    0 forwarded
    0 incoming packets discarded <----------
    49889719 incoming packets delivered
    49813641 requests sent out
    71 outgoing packets dropped <----------
[…]
Udp:
    5964 packets received
    93831 packets to unknown port received.
    0 packet receive errors
    5669588 packets sent
    SndbufErrors: 12345 <----------
    RcvbufErrors: 12345 <----------
[…]
```
(this output might be different for different "netstat" versions!)

Maybe also relevant:
- /proc/net/udp
- ifconfig

Some input: http://blog.packagecloud.io/eng/2016/06/22/monitoring-tuning-linux-networking-stack-receiving-data/#monitoring-network-devices