### PR TITLE
Improve IndexSize - read only for data hosts

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -29,11 +29,11 @@ Metrics/AbcSize:
 # Offense count: 1
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 140
+  Max: 145
 
 # Offense count: 3
 Metrics/CyclomaticComplexity:
-  Max: 12
+  Max: 13
 
 # Offense count: 23
 # Configuration parameters: CountComments.
@@ -42,7 +42,7 @@ Metrics/MethodLength:
 
 # Offense count: 2
 Metrics/PerceivedComplexity:
-  Max: 12
+  Max: 13
 
 # Offense count: 2
 Style/CaseEquality:

--- a/lib/bipbip/plugin/mongodb.rb
+++ b/lib/bipbip/plugin/mongodb.rb
@@ -68,8 +68,10 @@ module Bipbip
       data['slow_queries_time_avg'] = slow_queries_status['total']['time'].to_f / (slow_queries_status['total']['count'].to_f.nonzero? || 1)
       data['slow_queries_time_max'] = slow_queries_status['max']['time']
 
-      data['total_index_size'] = all_index_size / (1024 * 1024)
-      data['total_index_size_percentage_of_memory'] = (all_index_size.to_f / total_system_memory.to_f) * 100
+      unless router?
+        data['total_index_size'] = all_index_size / (1024 * 1024)
+        data['total_index_size_percentage_of_memory'] = (all_index_size.to_f / total_system_memory.to_f) * 100
+      end
 
       data
     end
@@ -123,6 +125,10 @@ module Bipbip
     # @return [Integer]
     def total_system_memory
       `free -b`.lines.to_a[1].split[1].to_i
+    end
+
+    def router?
+      fetch_server_status['process'] == 'mongos'
     end
 
     def fetch_slow_queries_status

--- a/lib/bipbip/version.rb
+++ b/lib/bipbip/version.rb
@@ -1,3 +1,3 @@
 module Bipbip
-  VERSION = '0.6.23'
+  VERSION = '0.6.24'
 end


### PR DESCRIPTION
Part of https://github.com/cargomedia/bipbip/pull/155

We should read the index size only for data related hosts. It means that: config, router, arbiter and even secondary should be excluded.

