### PR TITLE
Avoid "mustermann" in version 1.0.0.beta2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
-Gemfile.lock
-.rvmrc
+/Gemfile.lock
+/.rvmrc
 /pkg
+/.vagrant

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,11 +1,11 @@
 Vagrant.configure('2') do |config|
-  config.vm.box = 'cargomedia/debian-7-amd64-default'
+  config.vm.box = 'cargomedia/debian-8-amd64-default'
 
   config.vm.provision 'shell', inline: [
     'cd /vagrant',
     'sudo apt-get update',
     'sudo apt-get install -y g++ libsasl2-dev libmysqlclient-dev libxslt1-dev libxml2-dev',
-    'sudo gem install bundle',
-    'bundle install'
+    # 'sudo gem install bundle',
+    # 'bundle install'
   ].join(' && ')
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,7 +5,7 @@ Vagrant.configure('2') do |config|
     'cd /vagrant',
     'sudo apt-get update',
     'sudo apt-get install -y g++ libsasl2-dev libmysqlclient-dev libxslt1-dev libxml2-dev',
-    # 'sudo gem install bundle',
-    # 'bundle install'
+    'sudo gem install bundle',
+    'bundle install'
   ].join(' && ')
 end

--- a/bipbip.gemspec
+++ b/bipbip.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'redis', '~> 3.2.1'
   s.add_runtime_dependency 'gearman-ruby', '~> 4.0.5'
   s.add_runtime_dependency 'resque', '~> 1.25'
+  s.add_runtime_dependency 'sinatra', '~> 1.4.7' # this is workaround to avoid mustermann@1.0.0 installation
   s.add_runtime_dependency 'monit', '~> 0.3'
   s.add_runtime_dependency 'mongo', '~> 2.0.5'
   s.add_runtime_dependency 'bson', '~> 3.0.3'
@@ -25,7 +26,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'elasticsearch', '~> 1.0.6'
   s.add_runtime_dependency 'janus_gateway', '~> 0.0.10'
   s.add_runtime_dependency 'eventmachine', '~> 1.0.8'
-  s.add_runtime_dependency 'mustermann', '~> 0.2.0'
 
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec', '~> 2.0'

--- a/bipbip.gemspec
+++ b/bipbip.gemspec
@@ -30,5 +30,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec', '~> 2.0'
   s.add_development_dependency 'webmock', '~> 1.21'
-  s.add_development_dependency 'rubocop', '~> 0.35'
+  s.add_development_dependency 'rubocop', '~> 0.42.0'
 end

--- a/bipbip.gemspec
+++ b/bipbip.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'elasticsearch', '~> 1.0.6'
   s.add_runtime_dependency 'janus_gateway', '~> 0.0.10'
   s.add_runtime_dependency 'eventmachine', '~> 1.0.8'
-  s.add_runtime_dependency 'mustermann', '< 1.0.0'
+  s.add_runtime_dependency 'mustermann', '~> 0.2.0'
 
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec', '~> 2.0'

--- a/bipbip.gemspec
+++ b/bipbip.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'elasticsearch', '~> 1.0.6'
   s.add_runtime_dependency 'janus_gateway', '~> 0.0.10'
   s.add_runtime_dependency 'eventmachine', '~> 1.0.8'
+  s.add_runtime_dependency 'mustermann', '~> 0.4.0'
 
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec', '~> 2.0'

--- a/bipbip.gemspec
+++ b/bipbip.gemspec
@@ -30,5 +30,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec', '~> 2.0'
   s.add_development_dependency 'webmock', '~> 1.21'
-  s.add_development_dependency 'rubocop', '~> 0.35.0'
+  s.add_development_dependency 'rubocop', '~> 0.41.2'
 end

--- a/bipbip.gemspec
+++ b/bipbip.gemspec
@@ -30,5 +30,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec', '~> 2.0'
   s.add_development_dependency 'webmock', '~> 1.21'
-  s.add_development_dependency 'rubocop', '~> 0.42.0'
+  s.add_development_dependency 'rubocop', '~> 0.35.0'
 end

--- a/bipbip.gemspec
+++ b/bipbip.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'redis', '~> 3.2.1'
   s.add_runtime_dependency 'gearman-ruby', '~> 4.0.5'
   s.add_runtime_dependency 'resque', '~> 1.25'
-  s.add_runtime_dependency 'sinatra', '~> 1.4.7' # this is workaround to avoid mustermann@1.0.0 installation
+  s.add_runtime_dependency 'sinatra', '~> 1.4.7' # this is workaround for https://github.com/resque/resque/issues/1505
   s.add_runtime_dependency 'monit', '~> 0.3'
   s.add_runtime_dependency 'mongo', '~> 2.0.5'
   s.add_runtime_dependency 'bson', '~> 3.0.3'

--- a/bipbip.gemspec
+++ b/bipbip.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'elasticsearch', '~> 1.0.6'
   s.add_runtime_dependency 'janus_gateway', '~> 0.0.10'
   s.add_runtime_dependency 'eventmachine', '~> 1.0.8'
-  s.add_runtime_dependency 'mustermann', '~> 0.4.0'
+  s.add_runtime_dependency 'mustermann', '< 1.0.0'
 
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec', '~> 2.0'

--- a/lib/bipbip/plugin/elasticsearch.rb
+++ b/lib/bipbip/plugin/elasticsearch.rb
@@ -80,7 +80,7 @@ module Bipbip
     def stats_sum(keys)
       sum = 0
       (@stats ||= nodes_stats)['nodes'].each do |_node, stats|
-        sum += keys.inject(stats) { |a, e| (a.is_a?(Hash) && !a[e].nil?) ? a[e] : 0 }
+        sum += keys.inject(stats) { |a, e| a.is_a?(Hash) && !a[e].nil? ? a[e] : 0 }
       end
       sum
     end

--- a/lib/bipbip/plugin/fastcgi_php_opcache.rb
+++ b/lib/bipbip/plugin/fastcgi_php_opcache.rb
@@ -54,7 +54,7 @@ module Bipbip
       delta_misses = current_stats['misses'].to_f - previous_stats['misses'].to_f
 
       delta_total = delta_hits + delta_misses
-      hit_rate = delta_total == 0 ? 0 : (delta_hits / delta_total) * 100
+      hit_rate = delta_total.zero? ? 0 : (delta_hits / delta_total) * 100
       hit_rate.round(2)
     end
   end

--- a/lib/bipbip/plugin/janus_audioroom.rb
+++ b/lib/bipbip/plugin/janus_audioroom.rb
@@ -17,7 +17,7 @@ module Bipbip
       {
         'room_count' => audiorooms.count,
         'participant_count' => audiorooms.map { |room| room['num_participants'] }.reduce(0, :+),
-        'room_zero_participant_count' => audiorooms.count { |room| room['num_participants'] == 0 }
+        'room_zero_participant_count' => audiorooms.count { |room| (room['num_participants']).zero? }
       }
     end
 

--- a/lib/bipbip/plugin/janus_rtpbroadcast.rb
+++ b/lib/bipbip/plugin/janus_rtpbroadcast.rb
@@ -25,8 +25,8 @@ module Bipbip
       mountpoints = data['data']['list']
       streams = mountpoints.map { |mp| mp['streams'] }.flatten
 
-      packet_loss_audio_avg = streams.count != 0 ? streams.map { |s| s['stats']['audio']['packet-loss-rate'] || 0 }.reduce(0, :+) / streams.count : 0
-      packet_loss_video_avg = streams.count != 0 ? streams.map { |s| s['stats']['video']['packet-loss-rate'] || 0 }.reduce(0, :+) / streams.count : 0
+      packet_loss_audio_avg = streams.count.nonzero? ? streams.map { |s| s['stats']['audio']['packet-loss-rate'] || 0 }.reduce(0, :+) / streams.count : 0
+      packet_loss_video_avg = streams.count.nonzero? ? streams.map { |s| s['stats']['video']['packet-loss-rate'] || 0 }.reduce(0, :+) / streams.count : 0
 
       {
         'mountpoint_count' => mountpoints.count,
@@ -34,8 +34,8 @@ module Bipbip
         'streams_listener_count' => streams.map { |s| s['webrtc-endpoint']['listeners'] }.reduce(0, :+),
         'streams_waiter_count' => streams.map { |s| s['webrtc-endpoint']['waiters'] }.reduce(0, :+),
         'streams_bandwidth' => streams.map { |s| (s['stats']['video']['bitrate'] || 0) + (s['stats']['audio']['bitrate'] || 0) }.reduce(0, :+),
-        'streams_zero_fps_count' => streams.count { |s| s['frame']['fps'] == 0 },
-        'streams_zero_bitrate_count' => streams.count { |s| s['stats']['video']['bitrate'].nil? || s['stats']['video']['bitrate'] == 0 },
+        'streams_zero_fps_count' => streams.count { |s| (s['frame']['fps']).zero? },
+        'streams_zero_bitrate_count' => streams.count { |s| s['stats']['video']['bitrate'].nil? || (s['stats']['video']['bitrate']).zero? },
         'streams_packet_loss_audio_max' => streams.map { |s| (s['stats']['audio']['packet-loss-rate'] || 0) * 100 }.max,
         'streams_packet_loss_audio_avg' => packet_loss_audio_avg * 100,
         'streams_packet_loss_audio_count' => streams.map { |s| (s['stats']['audio']['packet-loss-count'] || 0) }.reduce(0, :+),

--- a/lib/bipbip/plugin/mongodb.rb
+++ b/lib/bipbip/plugin/mongodb.rb
@@ -118,7 +118,7 @@ module Bipbip
 
       database_list.map do |database|
         results = database.command('dbstats' => 1)
-        results.count == 0 ? 0 : results.documents.first['indexSize']
+        results.count.zero? ? 0 : results.documents.first['indexSize']
       end.reduce(:+)
     end
 
@@ -151,7 +151,7 @@ module Bipbip
           ]
         )
 
-        unless results.count == 0
+        unless results.count.zero?
           result = results.first
           max_time = result['max_time'].to_f / 1000
 

--- a/lib/bipbip/plugin/monit.rb
+++ b/lib/bipbip/plugin/monit.rb
@@ -32,7 +32,7 @@ module Bipbip
         data['All_Services_ok'] = status.services.any? do |service|
           error_flags_bitmap = service.status.to_i
           monitor_status = service.monitor.to_i
-          (monitor_status == MONITOR_NOT) || (error_flags_bitmap != 0)
+          (monitor_status == MONITOR_NOT) || error_flags_bitmap.nonzero?
         end ? 0 : 1
       rescue
         data['Running'] = 0

--- a/lib/bipbip/plugin/mysql.rb
+++ b/lib/bipbip/plugin/mysql.rb
@@ -67,7 +67,7 @@ module Bipbip
         name = metric[:name]
         unit = metric[:unit]
         data[name] = if 'Boolean' == unit
-                       (('ON' === stats[name] || 'Yes' === stats[name]) ? 1 : 0)
+                       ('ON' === stats[name] || 'Yes' === stats[name] ? 1 : 0)
                      else
                        stats[name].to_i
                      end

--- a/lib/bipbip/plugin/puppet.rb
+++ b/lib/bipbip/plugin/puppet.rb
@@ -27,7 +27,7 @@ module Bipbip
       has_changes = puppet_report.key?('changes')
 
       metrics = {
-        'report_ok' => ((has_events && has_changes && has_resources) ? 1 : 0),
+        'report_ok' => (has_events && has_changes && has_resources ? 1 : 0),
         'last_run_total_time' => puppet_report['time']['total'].to_i,
         'last_run_age' => report_age
       }

--- a/lib/bipbip/version.rb
+++ b/lib/bipbip/version.rb
@@ -1,3 +1,3 @@
 module Bipbip
-  VERSION = '0.6.24'
+  VERSION = '0.6.25'
 end


### PR DESCRIPTION
Part of https://github.com/cargomedia/puppet-packages/issues/1464

Currently `bipbip` tries to install [mustermann@1.0.0.beta2](https://rubygems.org/gems/mustermann/versions/1.0.0.beta2) which requires `ruby@2.2`.

Because of https://github.com/resque/resque/issues/1505
cc @njam @ppp0 