### PR TITLE
Add plugin from monitoring systemd unit/target and its dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ These service plugins ship with bipbip:
 - command
 - socket-redis
 - coturn
+- systemd-unit
 
 Please refer to [/docu/services.md](/docu/services.md) for information about the individual plugins and their configuration options.
 

--- a/bipbip.gemspec
+++ b/bipbip.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'elasticsearch', '~> 1.0.6'
   s.add_runtime_dependency 'janus_gateway', '~> 0.0.10'
   s.add_runtime_dependency 'eventmachine', '~> 1.0.8'
+  s.add_runtime_dependency 'komenda', '~> 0.1.6'
 
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec', '~> 2.0'

--- a/docu/services.md
+++ b/docu/services.md
@@ -188,3 +188,8 @@ Configuration options:
 ### janus-audioroom
 Configuration options:
 - **url** (optional): Will default to `http://localhost:8088/janus`.
+
+
+### systemd-unit
+Configuration options:
+- **unit_name**: Name of the main systemd unit. 

--- a/lib/bipbip/plugin/systemd_unit.rb
+++ b/lib/bipbip/plugin/systemd_unit.rb
@@ -1,6 +1,5 @@
 # encoding: utf-8
 
-require 'open3'
 require 'komenda'
 
 module Bipbip
@@ -12,24 +11,23 @@ module Bipbip
     end
 
     def monitor
-      data = Hash.new(0)
       main_unit = config['unit_name']
-      data['all_units_running'] = unit_dependencies(main_unit).all? { |unit| unit_is_active(unit) }
-      data
+      Hash.new('all_units_running' => unit_dependencies(main_unit).all? { |unit| unit_is_active(unit) } ? 1 : 0)
     end
 
     # @param [String] main_unit
     # @return [Array<String>]
     def unit_dependencies(main_unit)
-      Komenda.run(['systemctl','list-dependencies', '--plain', '--full', main_unit]).stdout.split("\n").map do |line|
-        line.gsub(/^● /, '')
+      result = Komenda.run(['systemctl', 'list-dependencies', '--plain', '--full', main_unit], fail_on_fail: true)
+      result.stdout.lines.map do |line|
+        line.strip.gsub(/^● /, '')
       end
     end
 
     # @param [String] unit
     # @return [TrueClass, FalseClass]
     def unit_is_active(unit)
-      Komenda.run(['systemctl','is-active', unit]).success?
+      Komenda.run(['systemctl', 'is-active', unit]).success?
     end
   end
 end

--- a/lib/bipbip/plugin/systemd_unit.rb
+++ b/lib/bipbip/plugin/systemd_unit.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 
 require 'open3'
+require 'komenda'
 
 module Bipbip
   class Plugin::SystemdUnit < Plugin
@@ -13,39 +14,22 @@ module Bipbip
     def monitor
       data = Hash.new(0)
       main_unit = config['unit_name']
-      data['all_units_running'] = units(main_unit).all? { |unit| unit_is_running(unit) }
+      data['all_units_running'] = unit_dependencies(main_unit).all? { |unit| unit_is_active(unit) }
       data
     end
 
     # @param [String] main_unit
     # @return [Array<String>]
-    def units(main_unit)
-      command = "for unit in $(systemctl list-dependencies --plain --full #{main_unit}); do if [ \"${unit}\" != \"●\" ]; then echo \"${unit}\"; fi; done"
-      exec_command(command).split("\n")
+    def unit_dependencies(main_unit)
+      Komenda.run(['systemctl','list-dependencies', '--plain', '--full', main_unit]).stdout.split("\n").map do |line|
+        line.gsub(/^● /, '')
+      end
     end
 
     # @param [String] unit
     # @return [TrueClass, FalseClass]
-    def unit_is_running(unit)
-      exec_command("systemctl is-active --quiet #{unit}; echo $?").to_i == 0
-    end
-
-    def exec_command(command)
-      output_stdout = output_stderr = exit_code = nil
-      Open3.popen3(command) do |_stdin, stdout, stderr, wait_thr|
-        output_stdout = stdout.read.chomp
-        output_stderr = stderr.read.chomp
-        exit_code = wait_thr.value
-      end
-
-      unless exit_code.success?
-        message = ['Command execution failed:', command]
-        message.push 'STDOUT:', output_stdout unless output_stdout.empty?
-        message.push 'STDERR:', output_stderr unless output_stderr.empty?
-        raise message.join("\n")
-      end
-
-      output_stdout
+    def unit_is_active(unit)
+      Komenda.run(['systemctl','is-active', unit]).success?
     end
   end
 end

--- a/lib/bipbip/plugin/systemd_unit.rb
+++ b/lib/bipbip/plugin/systemd_unit.rb
@@ -1,0 +1,49 @@
+require 'open3'
+
+module Bipbip
+  class Plugin::SystemdUnit < Plugin
+    def metrics_schema
+      [
+        { name: 'all_units_running', type: 'gauge', unit: 'Boolean' }
+      ]
+    end
+
+    def monitor
+      data = Hash.new(0)
+      main_unit = config['unit_name']
+      data['all_units_running'] = units(main_unit).all? { |unit| unit_is_running(unit) }
+      data
+    end
+
+    # @param [String] main_unit
+    # @return [Array<String>]
+    def units(main_unit)
+      command = "for unit in $(systemctl list-dependencies --plain --full #{main_unit}); do if [ \"${unit}\" != \"●\" ]; then echo \"${unit}\"; fi; done"
+      exec_command(command).split("\n")
+    end
+
+    # @param [String] unit
+    # @return [TrueClass, FalseClass]
+    def unit_is_running(unit)
+      exec_command("systemctl is-active --quiet #{unit}; echo $?").to_i == 0
+    end
+
+    def exec_command(command)
+      output_stdout = output_stderr = exit_code = nil
+      Open3.popen3(command) do |_stdin, stdout, stderr, wait_thr|
+        output_stdout = stdout.read.chomp
+        output_stderr = stderr.read.chomp
+        exit_code = wait_thr.value
+      end
+
+      unless exit_code.success?
+        message = ['Command execution failed:', command]
+        message.push 'STDOUT:', output_stdout unless output_stdout.empty?
+        message.push 'STDERR:', output_stderr unless output_stderr.empty?
+        raise message.join("\n")
+      end
+
+      output_stdout
+    end
+  end
+end

--- a/lib/bipbip/plugin/systemd_unit.rb
+++ b/lib/bipbip/plugin/systemd_unit.rb
@@ -12,7 +12,7 @@ module Bipbip
 
     def monitor
       main_unit = config['unit_name']
-      Hash.new('all_units_running' => unit_dependencies(main_unit).all? { |unit| unit_is_active(unit) } ? 1 : 0)
+      { 'all_units_running' => unit_dependencies(main_unit).all? { |unit| unit_is_active(unit) } ? 1 : 0 }
     end
 
     # @param [String] main_unit

--- a/lib/bipbip/plugin/systemd_unit.rb
+++ b/lib/bipbip/plugin/systemd_unit.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 require 'open3'
 
 module Bipbip

--- a/lib/bipbip/version.rb
+++ b/lib/bipbip/version.rb
@@ -1,3 +1,3 @@
 module Bipbip
-  VERSION = '0.6.26'
+  VERSION = '0.7.0'
 end

--- a/spec/bipbip/plugin/systemd_unit_spec.rb
+++ b/spec/bipbip/plugin/systemd_unit_spec.rb
@@ -1,0 +1,18 @@
+require 'bipbip'
+require 'bipbip/plugin/systemd_unit'
+
+describe Bipbip::Plugin::SystemdUnit do
+  let(:plugin) do
+    Bipbip::Plugin::SystemdUnit.new('systemd-unit', { 'unit_name' => 'foo.target' }, 10)
+  end
+
+  it 'should collect data' do
+    allow(plugin).to receive(:units).with('foo.target').and_return(%w(unit1 unit2))
+    allow(plugin).to receive(:unit_is_running).with('unit1').and_return(true)
+    allow(plugin).to receive(:unit_is_running).with('unit2').and_return(false)
+    plugin.monitor['all_units_running'].should eq(false)
+
+    allow(plugin).to receive(:unit_is_running).with('unit2').and_return(true)
+    plugin.monitor['all_units_running'].should eq(true)
+  end
+end

--- a/spec/bipbip/plugin/systemd_unit_spec.rb
+++ b/spec/bipbip/plugin/systemd_unit_spec.rb
@@ -1,3 +1,5 @@
+#encoding: utf-8
+
 require 'bipbip'
 require 'bipbip/plugin/systemd_unit'
 
@@ -7,12 +9,28 @@ describe Bipbip::Plugin::SystemdUnit do
   end
 
   it 'should collect data' do
-    allow(plugin).to receive(:units).with('foo.target').and_return(%w(unit1 unit2))
-    allow(plugin).to receive(:unit_is_running).with('unit1').and_return(true)
-    allow(plugin).to receive(:unit_is_running).with('unit2').and_return(false)
+    allow(plugin).to receive(:unit_dependencies).with('foo.target').and_return(%w(unit1 unit2))
+    allow(plugin).to receive(:unit_is_active).with('unit1').and_return(true)
+    allow(plugin).to receive(:unit_is_active).with('unit2').and_return(false)
     plugin.monitor['all_units_running'].should eq(false)
 
-    allow(plugin).to receive(:unit_is_running).with('unit2').and_return(true)
+    allow(plugin).to receive(:unit_is_active).with('unit2').and_return(true)
     plugin.monitor['all_units_running'].should eq(true)
+  end
+
+  it 'should systemctl list-dependencies' do
+    result = double('result')
+    allow(result).to receive(:stdout).and_return("foo.target\n● foo-dependency1.service\n● foo-dependency1@5000.service\n")
+
+    allow(Komenda).to receive(:run).with(["systemctl", "list-dependencies", "--plain", "--full", "foo.target"]).and_return(result)
+    plugin.unit_dependencies('foo.target').should eq(%w(foo.target foo-dependency1.service foo-dependency1@5000.service))
+  end
+
+  it 'should systemctl is-active' do
+    result = double('result')
+    allow(result).to receive(:success?).and_return(true)
+
+    allow(Komenda).to receive(:run).with(["systemctl", "is-active", "bar.target"]).and_return(result)
+    plugin.unit_is_active('bar.target').should eq(true)
   end
 end

--- a/spec/bipbip/plugin/systemd_unit_spec.rb
+++ b/spec/bipbip/plugin/systemd_unit_spec.rb
@@ -1,4 +1,4 @@
-#encoding: utf-8
+# encoding: utf-8
 
 require 'bipbip'
 require 'bipbip/plugin/systemd_unit'
@@ -12,17 +12,17 @@ describe Bipbip::Plugin::SystemdUnit do
     allow(plugin).to receive(:unit_dependencies).with('foo.target').and_return(%w(unit1 unit2))
     allow(plugin).to receive(:unit_is_active).with('unit1').and_return(true)
     allow(plugin).to receive(:unit_is_active).with('unit2').and_return(false)
-    plugin.monitor['all_units_running'].should eq(false)
+    plugin.monitor['all_units_running'].should eq(0)
 
     allow(plugin).to receive(:unit_is_active).with('unit2').and_return(true)
-    plugin.monitor['all_units_running'].should eq(true)
+    plugin.monitor['all_units_running'].should eq(1)
   end
 
   it 'should systemctl list-dependencies' do
     result = double('result')
     allow(result).to receive(:stdout).and_return("foo.target\n● foo-dependency1.service\n● foo-dependency1@5000.service\n")
 
-    allow(Komenda).to receive(:run).with(["systemctl", "list-dependencies", "--plain", "--full", "foo.target"]).and_return(result)
+    allow(Komenda).to receive(:run).with(%w(systemctl list-dependencies --plain --full foo.target), fail_on_fail: true).and_return(result)
     plugin.unit_dependencies('foo.target').should eq(%w(foo.target foo-dependency1.service foo-dependency1@5000.service))
   end
 
@@ -30,7 +30,10 @@ describe Bipbip::Plugin::SystemdUnit do
     result = double('result')
     allow(result).to receive(:success?).and_return(true)
 
-    allow(Komenda).to receive(:run).with(["systemctl", "is-active", "bar.target"]).and_return(result)
+    allow(Komenda).to receive(:run).with(%w(systemctl is-active bar.target)).and_return(result)
     plugin.unit_is_active('bar.target').should eq(true)
   end
 end
+
+# bump version
+# docu/readme


### PR DESCRIPTION
- Plugin configuration should allow to define a list of units/targets to monitor (similar like [log-parser config](https://github.com/cargomedia/bipbip/blob/master/docu/services.md#log-parser)).
- Each monitored unit should create 1 metric, which has value 0 or 1, indicating whether *all dependent units* are active.