### PR TITLE
Update gemspec version of "eventmachine" and "janus-gateway-ruby"

### DIFF
--- a/bipbip.gemspec
+++ b/bipbip.gemspec
@@ -24,8 +24,8 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'bson', '~> 4.0.0'
   s.add_runtime_dependency 'rb-inotify', '~> 0.9.5'
   s.add_runtime_dependency 'elasticsearch', '~> 1.0.6'
-  s.add_runtime_dependency 'janus_gateway', '~> 0.0.10'
-  s.add_runtime_dependency 'eventmachine', '~> 1.0.8'
+  s.add_runtime_dependency 'janus_gateway', '~> 0.0.13'
+  s.add_runtime_dependency 'eventmachine', '~> 1.2.0'
   s.add_runtime_dependency 'komenda', '~> 0.1.6'
 
   s.add_development_dependency 'rake'

--- a/lib/bipbip/version.rb
+++ b/lib/bipbip/version.rb
@@ -1,3 +1,3 @@
 module Bipbip
-  VERSION = '0.7.1'
+  VERSION = '0.7.2'
 end


### PR DESCRIPTION
Required
```
  s.add_runtime_dependency 'janus_gateway', '~> 0.0.13'
  s.add_runtime_dependency 'eventmachine', '~> 1.2.0'
```