### PR TITLE
Fix gearman priority aggregation

### DIFF
--- a/lib/bipbip/plugin/gearman.rb
+++ b/lib/bipbip/plugin/gearman.rb
@@ -5,9 +5,9 @@ end
 
 module Bipbip
   class Plugin::Gearman < Plugin
-    PRIORITY_LOW = 0
-    PRIORITY_NORMAL = 1
-    PRIORITY_HIGH = 2
+    JOB_PRIORITY_HIGH = 0
+    JOB_PRIORITY_NORMAL = 1
+    JOB_PRIORITY_LOW = 2
 
     def metrics_schema
       [
@@ -35,9 +35,9 @@ module Bipbip
       if config['persistence'] == 'mysql'
         stats = _fetch_mysql_priority_stats(config)
         priority_stats = {
-          jobs_queued_total_low: stats[PRIORITY_LOW],
-          jobs_queued_total_normal: stats[PRIORITY_NORMAL],
-          jobs_queued_total_high: stats[PRIORITY_HIGH]
+          jobs_queued_total_high: stats[JOB_PRIORITY_HIGH],
+          jobs_queued_total_normal: stats[JOB_PRIORITY_NORMAL],
+          jobs_queued_total_low: stats[JOB_PRIORITY_LOW]
         }
       end
 

--- a/lib/bipbip/version.rb
+++ b/lib/bipbip/version.rb
@@ -1,3 +1,3 @@
 module Bipbip
-  VERSION = '0.7.9'.freeze
+  VERSION = '0.7.10'.freeze
 end

--- a/spec/bipbip/plugin/gearman_spec.rb
+++ b/spec/bipbip/plugin/gearman_spec.rb
@@ -12,9 +12,9 @@ describe Bipbip::Plugin::Gearman do
     )
 
     plugin.stub(:_fetch_mysql_priority_stats).and_return(
-      Bipbip::Plugin::Gearman::PRIORITY_LOW => 5,
-      Bipbip::Plugin::Gearman::PRIORITY_NORMAL => 10,
-      Bipbip::Plugin::Gearman::PRIORITY_HIGH => 15
+      Bipbip::Plugin::Gearman::JOB_PRIORITY_LOW => 5,
+      Bipbip::Plugin::Gearman::JOB_PRIORITY_NORMAL => 10,
+      Bipbip::Plugin::Gearman::JOB_PRIORITY_HIGH => 15
     )
 
     data = plugin.monitor


### PR DESCRIPTION
See priority/integer reference https://github.com/gearman/gearmand/blob/4761b20023c0adf9c4704fc81bce6c70446857b6/libgearman-1.0/priority.h#L41

Should be
```
    PRIORITY_HIGH = 0
    PRIORITY_NORMAL = 1
    PRIORITY_LOW = 2
    PRIORITY_MAX = 3
```

Part of https://github.com/cargomedia/puppet-cargomedia/issues/1598

cc @njam