### PR TITLE
[mongodb] Query DBs status and stats only for master and primary members

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -23,25 +23,25 @@ Lint/UselessAssignment:
 
 # Offense count: 30
 Metrics/AbcSize:
-  Max: 82
+  Max: 86
 
 # Offense count: 1
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 152
+  Max: 154
 
 # Offense count: 4
 Metrics/CyclomaticComplexity:
-  Max: 13
+  Max: 15
 
 # Offense count: 31
 # Configuration parameters: CountComments.
 Metrics/MethodLength:
-  Max: 43
+  Max: 44
 
 # Offense count: 3
 Metrics/PerceivedComplexity:
-  Max: 13
+  Max: 15
 
 # Offense count: 2
 Style/CaseEquality:

--- a/bipbip.gemspec
+++ b/bipbip.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'eventmachine', '~> 1.2.0'
   s.add_runtime_dependency 'komenda', '~> 0.1.6'
 
-  s.add_development_dependency 'rake'
+  s.add_development_dependency 'rake', '~> 11.1.0'
   s.add_development_dependency 'rspec', '~> 2.0'
   s.add_development_dependency 'webmock', '~> 1.21'
   s.add_development_dependency 'rubocop', '~> 0.41.2'

--- a/bipbip.gemspec
+++ b/bipbip.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'eventmachine', '~> 1.2.0'
   s.add_runtime_dependency 'komenda', '~> 0.1.6'
 
+  # Pinned rake to version < v12 due to bug http://stackoverflow.com/q/35893584
   s.add_development_dependency 'rake', '~> 11.1.0'
   s.add_development_dependency 'rspec', '~> 2.0'
   s.add_development_dependency 'webmock', '~> 1.21'

--- a/lib/bipbip/plugin/mongodb.rb
+++ b/lib/bipbip/plugin/mongodb.rb
@@ -28,8 +28,6 @@ module Bipbip
 
     def monitor
       status = fetch_server_status
-      slow_queries_status = fetch_slow_queries_status
-      all_index_size = total_index_size
 
       data = {}
 
@@ -64,13 +62,18 @@ module Bipbip
         data['replication_lag'] = replication_lag
       end
 
-      data['slow_queries_count'] = slow_queries_status['total']['count']
-      data['slow_queries_time_avg'] = slow_queries_status['total']['time'].to_f / (slow_queries_status['total']['count'].to_f.nonzero? || 1)
-      data['slow_queries_time_max'] = slow_queries_status['max']['time']
+      if status['repl'] && status['repl']['ismaster'] == true
+        slow_queries_status = fetch_slow_queries_status
+        all_index_size = total_index_size
 
-      unless router?
-        data['total_index_size'] = all_index_size / (1024 * 1024)
-        data['total_index_size_percentage_of_memory'] = (all_index_size.to_f / total_system_memory.to_f) * 100
+        data['slow_queries_count'] = slow_queries_status['total']['count']
+        data['slow_queries_time_avg'] = slow_queries_status['total']['time'].to_f / (slow_queries_status['total']['count'].to_f.nonzero? || 1)
+        data['slow_queries_time_max'] = slow_queries_status['max']['time']
+
+        unless router?
+          data['total_index_size'] = all_index_size / (1024 * 1024)
+          data['total_index_size_percentage_of_memory'] = (all_index_size.to_f / total_system_memory.to_f) * 100
+        end
       end
 
       data

--- a/lib/bipbip/plugin/mongodb.rb
+++ b/lib/bipbip/plugin/mongodb.rb
@@ -4,8 +4,6 @@ module Bipbip
   class Plugin::Mongodb < Plugin
     def metrics_schema
       [
-        { name: 'flushing_last_ms', type: 'gauge', unit: 'ms' },
-        { name: 'btree_misses', type: 'gauge', unit: 'misses' },
         { name: 'op_inserts', type: 'counter' },
         { name: 'op_queries', type: 'counter' },
         { name: 'op_updates', type: 'counter' },
@@ -32,12 +30,6 @@ module Bipbip
 
       data = {}
 
-      if status['indexCounters']
-        data['btree_misses'] = status['indexCounters']['misses'].to_i
-      end
-      if status['backgroundFlushing']
-        data['flushing_last_ms'] = status['backgroundFlushing']['last_ms'].to_i
-      end
       if status['opcounters']
         data['op_inserts'] = status['opcounters']['insert'].to_i
         data['op_queries'] = status['opcounters']['query'].to_i

--- a/lib/bipbip/plugin/mongodb.rb
+++ b/lib/bipbip/plugin/mongodb.rb
@@ -28,6 +28,7 @@ module Bipbip
 
     def monitor
       status = fetch_server_status
+      all_index_size = total_index_size
 
       data = {}
 
@@ -64,16 +65,15 @@ module Bipbip
 
       if status['repl'] && status['repl']['ismaster'] == true
         slow_queries_status = fetch_slow_queries_status
-        all_index_size = total_index_size
 
         data['slow_queries_count'] = slow_queries_status['total']['count']
         data['slow_queries_time_avg'] = slow_queries_status['total']['time'].to_f / (slow_queries_status['total']['count'].to_f.nonzero? || 1)
         data['slow_queries_time_max'] = slow_queries_status['max']['time']
+      end
 
-        unless router?
-          data['total_index_size'] = all_index_size / (1024 * 1024)
-          data['total_index_size_percentage_of_memory'] = (all_index_size.to_f / total_system_memory.to_f) * 100
-        end
+      unless router?
+        data['total_index_size'] = all_index_size / (1024 * 1024)
+        data['total_index_size_percentage_of_memory'] = (all_index_size.to_f / total_system_memory.to_f) * 100
       end
 
       data

--- a/lib/bipbip/version.rb
+++ b/lib/bipbip/version.rb
@@ -1,3 +1,3 @@
 module Bipbip
-  VERSION = '0.7.10'.freeze
+  VERSION = '0.7.11'.freeze
 end

--- a/spec/bipbip/plugin/mongodb_spec.rb
+++ b/spec/bipbip/plugin/mongodb_spec.rb
@@ -14,12 +14,16 @@ describe Bipbip::Plugin::Mongodb do
       }
     )
 
+    plugin.stub(:total_index_size).and_return(50 * 1024 * 1024)
+    plugin.stub(:total_system_memory).and_return(200 * 1024 * 1024)
+
     data = plugin.monitor
+    data['replication_lag'].should eq(nil)
+    data['slow_queries_count'].should eq(nil)
     data['connections_current'].should eq(100)
     data['mem_resident'].should eq(1024)
-    data['replication_lag'].should eq(nil)
-    data['total_index_size'].should eq(nil)
-    data['slow_queries_count'].should eq(nil)
+    data['total_index_size'].should eq(50)
+    data['total_index_size_percentage_of_memory'].should eq(25)
   end
 
   it 'should collect replication lag' do
@@ -37,9 +41,12 @@ describe Bipbip::Plugin::Mongodb do
       ]
     )
 
+    plugin.stub(:total_index_size).and_return(50 * 1024 * 1024)
+    plugin.stub(:total_system_memory).and_return(200 * 1024 * 1024)
+
     data = plugin.monitor
     data['replication_lag'].should eq(3)
-    data['total_index_size'].should eq(nil)
+    data['slow_queries_count'].should eq(nil)
   end
 
   it 'should collect slow queries' do
@@ -75,7 +82,5 @@ describe Bipbip::Plugin::Mongodb do
     data['slow_queries_count'].should eq(48.4)
     data['slow_queries_time_avg'].should eq(0.5)
     data['slow_queries_time_max'].should eq(12)
-    data['total_index_size'].should eq(50)
-    data['total_index_size_percentage_of_memory'].should eq(25)
   end
 end

--- a/spec/bipbip/plugin/mongodb_spec.rb
+++ b/spec/bipbip/plugin/mongodb_spec.rb
@@ -51,27 +51,27 @@ describe Bipbip::Plugin::Mongodb do
 
   it 'should collect slow queries' do
     plugin.stub(:fetch_server_status).and_return(
-        'repl' => {
-            'ismaster' => true
-        }
+      'repl' => {
+        'ismaster' => true
+      }
     )
 
     plugin.stub(:fetch_replica_status).and_return(
-        'set' => 'rep1',
-        'members' => [
-            { 'stateStr' => 'PRIMARY', 'optime' => BSON::Timestamp.new(1000, 1) },
-            { 'stateStr' => 'SECONDARY', 'optime' => BSON::Timestamp.new(1003, 1), 'self' => true }
-        ]
+      'set' => 'rep1',
+      'members' => [
+        { 'stateStr' => 'PRIMARY', 'optime' => BSON::Timestamp.new(1000, 1) },
+        { 'stateStr' => 'SECONDARY', 'optime' => BSON::Timestamp.new(1003, 1), 'self' => true }
+      ]
     )
 
     plugin.stub(:fetch_slow_queries_status).and_return(
-        'total' => {
-            'count' => 48.4,
-            'time' => 24.2
-        },
-        'max' => {
-            'time' => 12
-        }
+      'total' => {
+        'count' => 48.4,
+        'time' => 24.2
+      },
+      'max' => {
+        'time' => 12
+      }
     )
 
     plugin.stub(:total_index_size).and_return(50 * 1024 * 1024)


### PR DESCRIPTION
Since WiredTiger/mongo@3.0 there is no possibility to list databases and stats for databases on secondary members.

Only partial data is collected
```
I, [2017-01-27T10:36:43.914870 #18952]  INFO -- : Starting plugin mongodb with config {"hostname"=>"0.0.0.0", "port"=>27018, "user"=>"xxx", "password"=>"xxx"}
E, [2017-01-27T10:38:44.022819 #18952] ERROR -- mongodb rep1-db7.mongodb.xxx.net::mongodb::0_0_0_0: Measurement timeout of 120.0 seconds reached.
E, [2017-01-27T10:40:44.023639 #18952] ERROR -- mongodb rep1-db7.mongodb.xxx.net::mongodb::0_0_0_0: Measurement timeout of 120.0 seconds reached.
```