### PR TITLE
BO-82 [socket-redis] add token authentication for status end-point

### DIFF
--- a/docu/services.md
+++ b/docu/services.md
@@ -182,6 +182,7 @@ Boolean values `true`, `false` will be replaced with `1`, `0` for both modes.
 ### socket-redis
 Configuration options:
 - **url**: URL of `socket-redis` [status](https://github.com/cargomedia/socket-redis#status-request). Defaults to `http://localhost:8085/status`
+- **status_token**: Secret token for status end-point authentication 
 
 ### coturn
 Configuration options:

--- a/docu/services.md
+++ b/docu/services.md
@@ -182,7 +182,7 @@ Boolean values `true`, `false` will be replaced with `1`, `0` for both modes.
 ### socket-redis
 Configuration options:
 - **url**: URL of `socket-redis` [status](https://github.com/cargomedia/socket-redis#status-request). Defaults to `http://localhost:8085/status`
-- **status_token**: Secret token for status end-point authentication 
+- **status_token** (optional): Secret token for status end-point authentication 
 
 ### coturn
 Configuration options:

--- a/lib/bipbip/plugin/socket_redis.rb
+++ b/lib/bipbip/plugin/socket_redis.rb
@@ -23,7 +23,13 @@ module Bipbip
       url = config['url'] || 'http://localhost:8085/status'
       uri = URI.parse(url)
 
-      response = Net::HTTP.get_response(uri)
+      request = Net::HTTP::Get.new(uri)
+      request['authorization'] = "token #{config['status_token']}"
+
+      response = Net::HTTP.start(uri.hostname, uri.port) { |http|
+        http.request(request)
+      }
+
       unless response.code == '200'
         raise "Invalid response from server at `#{url}`. Response code `#{response.code}`, message `#{response.message}`, body `#{response.body}`"
       end

--- a/lib/bipbip/plugin/socket_redis.rb
+++ b/lib/bipbip/plugin/socket_redis.rb
@@ -26,9 +26,9 @@ module Bipbip
       request = Net::HTTP::Get.new(uri)
       request['authorization'] = "token #{config['status_token']}"
 
-      response = Net::HTTP.start(uri.hostname, uri.port) { |http|
+      response = Net::HTTP.start(uri.hostname, uri.port) do |http|
         http.request(request)
-      }
+      end
 
       unless response.code == '200'
         raise "Invalid response from server at `#{url}`. Response code `#{response.code}`, message `#{response.message}`, body `#{response.body}`"

--- a/lib/bipbip/plugin/socket_redis.rb
+++ b/lib/bipbip/plugin/socket_redis.rb
@@ -24,7 +24,7 @@ module Bipbip
       uri = URI.parse(url)
 
       request = Net::HTTP::Get.new(uri)
-      request['authorization'] = "token #{config['status_token']}"
+      request['authorization'] = "token #{config['status_token']}" if config['status_token']
 
       response = Net::HTTP.start(uri.hostname, uri.port) do |http|
         http.request(request)

--- a/lib/bipbip/version.rb
+++ b/lib/bipbip/version.rb
@@ -1,3 +1,3 @@
 module Bipbip
-  VERSION = '0.7.11'.freeze
+  VERSION = '0.7.12'.freeze
 end


### PR DESCRIPTION
Part of https://github.com/cargomedia/puppet-cargomedia/issues/1702
Depends on https://github.com/cargomedia/socket-redis/pull/97